### PR TITLE
Improved Readme on Installing on Windows with WSL2

### DIFF
--- a/docs/1_installation/3_windows_wsl.md
+++ b/docs/1_installation/3_windows_wsl.md
@@ -3,10 +3,10 @@
 This guide is currently tested on Windows 10 (22H2) and Windows 11.
 
 ## Install Windows Subsystem for Linux (WSL). 
-Remember to run Powershell in Administrator mode either by right clicking and selecting 'Run as administrator' or by typing PowerShell in 'Run dialog box' of Windows and pressing ```Ctrl+Shift+Enter``` key combination.
+Remember to run Powershell in Administrator mode either by right clicking and selecting 'Run as administrator' or by typing PowerShell in 'Run' dialog box of Windows and pressing `Ctrl+Shift+Enter` key combination.
 
 Install Ubuntu distribution of Linux by executing the command:
-```wsl --install --distribution Ubuntu```
+`wsl --install --distribution Ubuntu`
 or
 Install Ubuntu distribution of Linux from Microsoft Store by using guide [here](https://learn.microsoft.com/en-us/windows/wsl/install).
 
@@ -111,4 +111,6 @@ You can run Ethereal Engine stack by running:
 ```bash
 npm run dev
 ```
-Now run Ethereal Engine in browser by navigating to [this link](https://127.0.0.1:3000/location/default). If it keeps displaying 'loading routes' progress for a long time, it is due to the fact that you have to allow certificates. If you open dev tools on above tab in chrome and then go to console of developer tools you will see some errors of address starting with wss. Replace that wss with http and open it in new tab, accept the certificate and reload your ethereal engine tab.
+Now run Ethereal Engine in browser by navigating to [this link](https://127.0.0.1:3000/location/default).   
+> If it keeps displaying 'loading routes' progress for a long time, it is due to the fact that you have to allow certificates.   
+> Open Developer tools in Chrome by clicking the side menu with three dots, then `More tools > Developer tools` (or use `Ctrl+Shift+I`) and then go to the 'Console' tab. You will see some errors in URL address starting with 'wss'. Replace 'wss' with 'https' and open it in new tab. Accept the certificate and reload your Ethereal Engine tab.

--- a/docs/1_installation/3_windows_wsl.md
+++ b/docs/1_installation/3_windows_wsl.md
@@ -1,9 +1,13 @@
 # Installing on Windows with WSL2
 
-This guide is currently tested on Windows 11.
+This guide is currently tested on Windows 10 (22H2) and Windows 11.
 
-## Install Windows Subsystem for Linux (WSL)
+## Install Windows Subsystem for Linux (WSL). 
+Remember to run Powershell in Administrator mode either by right clicking and selecting 'Run as administrator' or by typing PowerShell in 'Run dialog box' of Windows and pressing ```Ctrl+Shift+Enter``` key combination.
 
+Install Ubuntu distribution of Linux by executing the command:
+```wsl --install --distribution Ubuntu```
+or
 Install Ubuntu distribution of Linux from Microsoft Store by using guide [here](https://learn.microsoft.com/en-us/windows/wsl/install).
 
 Alternatively, you can follow these instructions as well:
@@ -15,16 +19,19 @@ Once WSL is installed, make sure to:
 
 - [Set up your Linux username and password](https://learn.microsoft.com/en-us/windows/wsl/setup/environment#set-up-your-linux-username-and-password)
 - [Update and upgrade packages](https://learn.microsoft.com/en-us/windows/wsl/setup/environment#update-and-upgrade-packages)
+- Verify Ubuntu distribution using the command: 'lsb_release -a'
+- You can verify WSL and Ubuntu  installation by using the command in PowerShell: 'wsl -l -v'
 
 ## Install Docker Desktop
 
 Install docker desktop with WSL 2 backend. You can find the instructions [here](https://docs.docker.com/desktop/install/windows-install/).
 
-Once docker desktop is installed and running make sure to enable your WSL distribution. You can do so from Docker Desktop App by visiting `Settings > Resources > WSL Integration`. Make sure to hit 'Apply & Restart'.
+Once docker desktop is installed and running make sure to enable your WSL distribution. You can do so from Docker Desktop App by visiting `Settings > Resources > WSL Integration`. Enable integartion with Ubuntu. Make sure to hit 'Apply & Restart'.
 
 ![Docker Desktop WSL Distro](../2_devops_deployment/images/docker-desktop-wsl-distro.jpg)
 
-## Install Node
+## Install Node. 
+Run Powershell in Administrator mode. Run Ubuntu using command : `wsl`. After logging on run the following command: `cd ~/` to ensure that the installation of Node and other packages mentioned below is done in Ubuntu.
 
 In your WSL Ubuntu terminal, if node (`node --version`) isn't already installed on your machine. You can do so by first installing `nvm` by running following commands:
 
@@ -37,13 +44,13 @@ export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion" # This loads nvm bash_completion
 ```
 
-You can verify nvm by using `nvm --version` command. Afterwards, install node by using:
+You can verify nvm by using `nvm --version` command. Afterwards, install Node (version between 16.0 and 18.0 both inclusive) by using:
 
 ```bash
-nvm install node
+nvm install 16.19
 ```
 
-You can verify nvm by using `node --version` command.
+You can verify node version by using `node --version` command.
 
 ## Install Python 3
 
@@ -69,13 +76,13 @@ You can verify make by using `make --version` command.
 
 ## Clone Ethereal Engine repo to your local machine
 
-Clone Ethereal Engine repo on your machine by running following command in WSL Ubuntu terminal.
+Clone Ethereal Engine repo on your machine by running following command in WSL Ubuntu terminal. You can check the directory in which you are sitting by the command: `pwd`
 
 ```bash
-git clone https://github.com/etherealengine/etherealengine.git etherealengine
+git clone https://github.com/etherealengine/etherealengine --depth 1
 ```
-
-If `.env.local` file does not exist in the root of your repo folder then create it by duplicating `.env.local.default`.
+Change directory to the location where etherealengine repo is cloned `cd etherealengine`
+If `.env.local` file does not exist in the root of your repo folder then create it by duplicating `.env.local.default`. Command: `cp .env.local.default .env.local`
 
 Afterwards, install npm packages using:
 
@@ -104,3 +111,4 @@ You can run Ethereal Engine stack by running:
 ```bash
 npm run dev
 ```
+Now run Ethereal Engine in browser by navigating to [this link](https://127.0.0.1:3000/location/default). If it keeps displaying 'loading routes' progress for a long time, it is due to the fact that you have to allow certificates. If you open dev tools on above tab in chrome and then go to console of developer tools you will see some errors of address starting with wss. Replace that wss with http and open it in new tab, accept the certificate and reload your ethereal engine tab.


### PR DESCRIPTION
File modified: docs/1_installation/3_windows_wsl.md
Modified the OS versions it was tested on. Added advisory for running Powershell in administrator mode. Added command to install current LTS version of Ubuntu. Added command to verify installed Ubuntu distribution. Added advisory to ensure that installation of Node and other packages is done in Ubuntu. Added command to install Node version between 16.0 and 18.0. Added instructions on certificates and address error with wss.