### PR TITLE
doc: Delete CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,0 @@
-# Change Log
-
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.


### PR DESCRIPTION
Conventional commits do not seem to be used anymore by the engine and related projects.
This removes the notice from this repository, since the file is completely empty.