### PR TITLE
[devops] chg: Update Docusaurus to v3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "react": "^18.2.0"
   },
   "dependencies": {
-    "@docusaurus/core": "^3.1.1",
-    "@docusaurus/preset-classic": "^3.1.1",
+    "@docusaurus/core": "^3.2.0",
+    "@docusaurus/preset-classic": "^3.2.0",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",
@@ -37,9 +37,9 @@
     "react-dom": "^18.0.0"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "^3.1.1",
-    "@docusaurus/tsconfig": "^3.1.1",
-    "@docusaurus/types": "^3.1.1",
+    "@docusaurus/module-type-aliases": "^3.2.0",
+    "@docusaurus/tsconfig": "^3.2.0",
+    "@docusaurus/types": "^3.2.0",
     "@ocular-d/vale-bin": "^2.29.6",
     "@tsconfig/docusaurus": "1.0.7",
     "@types/node": "^20.10.3",


### PR DESCRIPTION
**Important**: Breaks the current website. Version must be 3.1.`0` to fix the CSS issues.
- [ ] https://github.com/EtherealEngine/etherealengine-docs/pull/160

Issue conversation is tracked in Docusaurus upstream:
https://github.com/facebook/docusaurus/issues/10005