### PR TITLE
chg: Added the new version of the installation guide for macOS

### DIFF
--- a/docs/manual/01_install/02_macOSX.md
+++ b/docs/manual/01_install/02_macOSX.md
@@ -1,49 +1,113 @@
 ---
-sidebar_label: Mac OS X
+sidebar_label: macOS
 ---
-# Installing on Mac OS X
 
-1. Go to the root folder where Ethereal Engine is stored and run
+# Installing on macOS
+
+## Introduction
+
+This guide details the installation process for the iR Engine on macOS devices.
+
+## Prerequisites
+
+Before starting the installation, ensure you have the following tools installed on your system:
+
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/)
+- [nvm (Node Version Manager)](https://github.com/nvm-sh/nvm)
+- [Homebrew](https://brew.sh/)
+- [Python 3](https://www.python.org/downloads/)
+- [pip](https://pip.pypa.io/en/stable/installation/)
+
+## Installation instructions
+
+Follow these steps to set up the iR Engine on your macOS device.
+
+### Step 1: Prepare your project
+
+First, generate a copy of the project by cloning the repository and navigate to the project directory:
+
+1. Open your terminal
+2. Clone the repository by running:
+
+   ```bash
+   git clone https://github.com/EtherealEngine/etherealengine-docs.git
+   ```
+
+3. Navigate to the directory of the cloned repository:
+
+   ```bash
+   cd etherealengine-docs
+   ```
+
+### Step 2: Set up environment variables
+
+The iR Engine requires specific environment settings. Configure them by running:
+
+```bash
+cp .env.local.default .env.local
+```
+
+This command creates a copy of the default environment file, `.env.local.default`, renaming it to `.env.local` for use by the application.
+
+### Step 3: Install and activate the recommended Node.js version
+
+The iR Engine functions with a specific Node.js version, outlined in the `.nvmrc` file. To activate the recommended version, run:
+
+```bash
+nvm use
+```
+
+**Command output options**:
+
+- **If the version is found (✅):** The system switches to the recommended Node.js version.
+- **If the version is not found (❌):** The system returns a message indicating the missing version.  
+To resolve, run the following commands:
+  1. Install the missing version:
+
+     ```bash
+     nvm install <version>
+     ```
+
+  2. Activate the version:
+
+     ```bash
+     nvm use
+     ```
+
+### Step 4: Install dependencies
+
+Install the required dependencies by running:
+
 ```bash
 npm install
-npm run dev-docker
-npm run dev-reinit
 ```
-Or if you are on a M1 based Mac:
-```bash
-# Recommended
-1. Duplicate the Terminal app, and configure it to run in Rosetta
-2. Run the above commands in Rosetta Terminal
 
-# Not recommended
-yarn install
-```
-> _`node-darwin` sometimes doesn't get installed properly On Apple chips. Using yarn fixes this issue._
+Upon completion, proceed to initialize and run your development environment.
 
-2. Start docker in the background and then run:
+## Run your development environment
+
+This section contains the instructions to run your local development environment.
+
+### Step 1: Start Docker and initialize the database
+
+1. Open Docker Desktop
+
+2. Initialize the database by running:
+
+   ```bash
+   npm run dev-reinit
+   ```
+
+### Step 2: Start the development environment
+
+Launch the iR Engine development environment with:
+
 ```bash
 npm run dev
 ```
-This will open the MariaDB and SQL scripts on the docker and will start the servers
 
-3. To make sure your environment is set and running properly go to:  
-   https://localhost:3000/location/default  
-   You should be able to walk around an empty 3D scene.
+This command opens the application at `http://localhost:3000/location/default` in your web browser.
 
-> _Note: Make sure you are on Node.js >= 18 and have docker running._
+### Step 3: Open your development environment
 
-## Troubleshooting Mac
-- If you find issues on your terminal saying  
-  `access-denied for user server@localhost`  
-  then you can use this command:  
-```bash
-brew services stop mysql
-```
-
-- If you find issues on your terminal saying  
-  `An unexpected error occurred: "expected workspace package`  
-  while using yarn then you can use this command  
-```bash
-yarn policies set-version 1.18.0
-```
-> _Note: This happens because yarn > 1.18 sometimes doesn't work properly with `lerna`_
+Navigate to the application's URL in your browser to start working with the iR Engine development environment.

--- a/docs/manual/01_install/02_macOSX.md
+++ b/docs/manual/01_install/02_macOSX.md
@@ -10,11 +10,11 @@ This guide details the installation process for the iR Engine on macOS devices.
 
 ## Prerequisites
 
-Before starting the installation, ensure you have the following tools installed on your system:
+Ensure you have the following tools installed on your system before starting the installation:
 
+- [Homebrew](https://brew.sh/)
 - [Docker Desktop](https://www.docker.com/products/docker-desktop/)
 - [nvm (Node Version Manager)](https://github.com/nvm-sh/nvm)
-- [Homebrew](https://brew.sh/)
 - [Python 3](https://www.python.org/downloads/)
 - [pip](https://pip.pypa.io/en/stable/installation/)
 
@@ -30,13 +30,13 @@ First, generate a copy of the project by cloning the repository and navigate to 
 2. Clone the repository by running:
 
    ```bash
-   git clone https://github.com/EtherealEngine/etherealengine-docs.git
+   git clone https://github.com/EtherealEngine/etherealengine.git
    ```
 
 3. Navigate to the directory of the cloned repository:
 
    ```bash
-   cd etherealengine-docs
+   cd etherealengine
    ```
 
 ### Step 2: Set up environment variables


### PR DESCRIPTION
I have created this PR to submit the updated macOS installation guide to our site.

@heysokam and @DanielBelmes, could you please review the content provided?

### Things to consider

I have included Python 3, Homebrew, and pip as prerequisites. While our guide does not cover the installation of these tools, I have provided their installation links in the prerequisites section.

We will address troubleshooting steps in the second iteration of the guide. This will follow the completion of the changes to the repo that @DanielBelmes is working on, allowing us to fully test the document on a clean device.

I plan to test the final guide with someone unfamiliar with the engine to ensure its effectiveness.

### To review

For @DanielBelmes:
 - [ ] Content accuracy
 - [ ] Installation workflow

For @heysokam:
  - [x] Grammar
  - [x] Information architecture
