### PR TITLE
Replacing the instances where Ethereal Engine is mentioned in the Manual

### DIFF
--- a/docs/manual/01_install/01_linux.md
+++ b/docs/manual/01_install/01_linux.md
@@ -56,7 +56,7 @@ npm run dev-docker
 npm run dev-reinit
 npm run dev
 ```
-Now run Ethereal Engine in your browser by navigating to [this link](https://localhost:3000/location/default).  
+Now run iR Engine in your browser by navigating to [this link](https://localhost:3000/location/default).  
 
 ### Accept Certificates
 <AcceptCertificates />
@@ -66,7 +66,7 @@ You can administrate many features from the admin panel found at the `/admin` ro
 _eg: `https://localhost:3000/admin` when working in a local deployment._
 
 To give administration rights to a user:
-- Open any page in your Ethereal Engine deployment
+- Open any page in your iR Engine deployment
 - Open the user menu _(icon at the top-right of the screen)_
 - Click on `Show API key`
 - Copy that key to your clipboard _(note: there is an icon to the right of this box for this purpose)_

--- a/docs/manual/01_install/03_windows.md
+++ b/docs/manual/01_install/03_windows.md
@@ -10,7 +10,7 @@ sidebar_label: Windows 10+
 4. Add the path to `MSbuild.exe` _(which stored in Visual Studio's folder)_ into the `PATH` env variable  
   _eg: `C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin`_
 5. Make sure to install all windows prerequisites for Mediasoup as mentioned on: [https://mediasoup.org/documentation/v3/mediasoup/installation/#windows](https://mediasoup.org/documentation/v3/mediasoup/installation/#windows)
-6. Install all dependencies using `npm install` from the root folder where you cloned Ethereal Engine.
+6. Install all dependencies using `npm install` from the root folder where you cloned iR Engine.
 
 > Troubleshooting:  
 

--- a/docs/manual/01_install/03_windowsWSL.md
+++ b/docs/manual/01_install/03_windowsWSL.md
@@ -66,8 +66,8 @@ You can verify your Node version with the command: `node --version`.
 
 <MakeUbuntu />
 
-## Clone Ethereal Engine repo to your local machine
-Clone Ethereal Engine repo on your machine by running the following command from your WSL Ubuntu terminal:
+## Clone iR Engine repo to your local machine
+Clone iR Engine repo on your machine by running the following command from your WSL Ubuntu terminal:
 <CloneInstructions />
 
 Change directory to the location where `etherealengine` repository is cloned with:
@@ -75,7 +75,7 @@ Change directory to the location where `etherealengine` repository is cloned wit
 pwd                 # Prints the current working directory
 cd etherealengine   # Change directory to `etherealengine`
 ```
-If an `.env.local` file does not exist in the root of your Ethereal Engine repository folder, then create it by duplicating the `.env.local.default` file:
+If an `.env.local` file does not exist in the root of your iR Engine repository folder, then create it by duplicating the `.env.local.default` file:
 ```bash
 cp .env.local.default .env.local
 ```
@@ -86,7 +86,7 @@ npm install
 ```
 
 > Note: If you find issues related to `mediasoup` when running `npm install`, then:
-> - Remove the `mediasoup` package from `packages/instanceserver/package.json` file of Ethereal Engine's source code.
+> - Remove the `mediasoup` package from `packages/instanceserver/package.json` file of iR Engine's source code.
 > - Run `npm install` again.
 > - Run: `npm install mediasoup@3 -w @etherealengine/instanceserver`
 
@@ -97,11 +97,11 @@ npm run dev-reinit
 ```
 
 ## Start the Engine
-Run the Ethereal Engine's stack with:
+Run the iR Engine's stack with:
 ```bash
 npm run dev
 ```
-If everything went well, you will now be able to open Ethereal Engine in your browser by navigating to [this link](https://localhost:3000/location/default).  
+If everything went well, you will now be able to open iR Engine in your browser by navigating to [this link](https://localhost:3000/location/default).  
 
 ## Accept Certificates
 <AcceptCertificates />

--- a/docs/manual/01_install/04_controlCenter.md
+++ b/docs/manual/01_install/04_controlCenter.md
@@ -241,7 +241,7 @@ This section shows various actions that can be activated on the currently select
   It will be disabled and have a spinner in it when a configuration is already running.
 
 - **Launch Button**: ![Launch Button](../images/controlCenter/options-panel-launch.jpg)  
-  This button will open iR Engine's default location in your browser as [discussed](#5-launch-ethereal-engine) later.
+  This button will open iR Engine's default location in your browser as [discussed](#5-launch-ir-engine) later.
 
 ### 3.4. System Status
 This section will show whether or not the system requirements are currently met.  

--- a/docs/manual/01_install/04_controlCenter.md
+++ b/docs/manual/01_install/04_controlCenter.md
@@ -8,23 +8,23 @@ import StepVariables from '../_partials/controlCenter/step_variables.md'
 import StepSummary from '../_partials/controlCenter/step_summary.md'
 
 # Control Center: Getting Started
-Ethereal Engine's Control Center is a self-contained Metaverse world in a box. Take what you need or launch the full stack.  
-The Control Center is a desktop app to manage an Ethereal Engine cluster.
+iR Engine's Control Center is a self-contained Metaverse world in a box. Take what you need or launch the full stack.  
+The Control Center is a desktop app to manage an iR Engine cluster.
 
-We know it's been complicated to build with Ethereal Engine and we've made this tool to give the community easy access to the engine. We would love to see your creations and invite you all to come build with us.
+We know it's been complicated to build with iR Engine and we've made this tool to give the community easy access to the engine. We would love to see your creations and invite you all to come build with us.
 
 ## Overview
-The Ethereal Engine Control Center app provides access to various functionalities which includes:
-- Configure your Ethereal Engine in a cluster in just a few clicks.
-- View status of Ethereal Engine dependencies on your local system.
-- Manage an Ethereal Engine deployment through admin panel.
+The iR Engine Control Center app provides access to various functionalities which includes:
+- Configure your iR Engine in a cluster in just a few clicks.
+- View status of iR Engine dependencies on your local system.
+- Manage an iR Engine deployment through admin panel.
 - Manage kubernetes cluster through its dashboard.
 - Manage IPFS node running in the cluster.
 - Execute commands against rippled server.
 - See realtime logs of different actions being performed.
 
 ## 1. Downloading Control Center App
-In order to download Ethereal Engine Control Center App, navigate to [releases](https://github.com/EtherealEngine/etherealengine-control-center/releases) page and download the latest version of the App.
+In order to download iR Engine Control Center App, navigate to [releases](https://github.com/EtherealEngine/etherealengine-control-center/releases) page and download the latest version of the App.
 - **Windows** _(and WSL)_: Download the `.exe` file
 
   > You will need to allow permission for executing ps1 scripts.  
@@ -67,7 +67,7 @@ In this step, you will need to provide the following information:
 - **Cluster Type:**  
   This will be the kubernetes distribution you want to use.  
   There are two local distributions at the time of this writing: MicroK8s(recommended) and Minikube.  
-  There is also a Custom type which allows you to connect to an existing Ethereal Engine cluster.
+  There is also a Custom type which allows you to connect to an existing iR Engine cluster.
   > Currently, `MicroK8s` is supported on Windows & Linux while `Minikube` is supported on Linux only.
 
 - **Prerequisites:**  
@@ -129,7 +129,7 @@ In this step, you will need to provide following information regarding desired c
 - **Config Type: Text**  
   Loads kubeconfig from a text.
 - **Context**:  
-  This is the selected kube context of the cluster in which your Ethereal Engine deployment exists.  
+  This is the selected kube context of the cluster in which your iR Engine deployment exists.  
   The dropdown will show all contexts that exist for the selected config type.
 
 ### 2.3.2. Deployment
@@ -183,7 +183,7 @@ The Navbar allows navigation and various utility options.
   Navigates to [workloads](#6-workloads) screen of selected cluster.
 
 - **Admin**:  
-  Navigates to ethereal engine [admin](#7-admin-dashboard) panel of selected cluster.
+  Navigates to iR Engine [admin](#7-admin-dashboard) panel of selected cluster.
 
 - **K8 Dashboard**:  
   Navigates to kubernetes [web dashboard](#8-k8-dashboard) of selected kubernetes distribution.
@@ -196,7 +196,7 @@ The Navbar allows navigation and various utility options.
   Visible only when ripple stack is enabled.
 
 - **Change Theme Icon**: ![Change Theme Icon](../images/controlCenter/navbar-theme.jpg)  
-  Allows to toggle between vaporware, light & dark themes. The color scheme of these themes are similar to ethereal engine.
+  Allows to toggle between vaporware, light & dark themes. The color scheme of these themes are similar to iR Engine.
 
 - **Support Icon**: ![Support Icon](../images/controlCenter/navbar-support.jpg)  
   Opens a dropdown menu to allow reaching out to support via Discord or Github.
@@ -216,11 +216,11 @@ This section shows various actions that can be activated on the currently select
   Name that you entered in create cluster dialog. _eg: `Local`_
 
 - **Engine Git Status**: ![Cluster Icon](../images/controlCenter/options-panel-git-engine.jpg)  
-  View and change the state of your local Ethereal Engine GitHub repo.  
+  View and change the state of your local iR Engine GitHub repo.  
   View current branch, pull incoming changes and push outgoing changes.  
 
 - **Ops Git Status**: ![Cluster Icon](../images/controlCenter/options-panel-git-ops.jpg)  
-  View the current status of your local Ethereal Engine ops GitHub repo.  
+  View the current status of your local iR Engine ops GitHub repo.  
   You can perform the same actions explained in the previous bullet point _(Engine Git Status)_.
 
 - **Refresh Icon**: ![Refresh Icon](../images/controlCenter/options-panel-refresh.jpg)  
@@ -241,7 +241,7 @@ This section shows various actions that can be activated on the currently select
   It will be disabled and have a spinner in it when a configuration is already running.
 
 - **Launch Button**: ![Launch Button](../images/controlCenter/options-panel-launch.jpg)  
-  This button will open Ethereal Engine's default location in your browser as [discussed](#5-launch-ethereal-engine) later.
+  This button will open iR Engine's default location in your browser as [discussed](#5-launch-ethereal-engine) later.
 
 ### 3.4. System Status
 This section will show whether or not the system requirements are currently met.  
@@ -264,11 +264,11 @@ Otherwise you will need to use the configure dialog.
 :::
 
 ### 3.5. Apps Status
-This section shows the current status of all the apps required to run an Ethereal Engine deployment.
+This section shows the current status of all the apps required to run an iR Engine deployment.
 ![Apps Status](../images/controlCenter/status-apps.jpg)
 
 ### 3.6. Engine Status
-This section shows the current status of various components of an Ethereal Engine deployment in your local kubernetes distribution.
+This section shows the current status of various components of an iR Engine deployment in your local kubernetes distribution.
 ![Engine Status](../images/controlCenter/status-engine.jpg)
 
 ### 3.7. Logs
@@ -328,19 +328,19 @@ Always clear your logs before running the configure script to trace its output e
   Pay close attention to last few lines of the [logs](#37-logs). They will contain the reason why the script failed.
   :::
 
-## 5. Launch Ethereal Engine
-![Launch Ethereal Engine](../images/controlCenter/engine-launch.jpg)
+## 5. Launch iR Engine
+![Launch iR Engine](../images/controlCenter/engine-launch.jpg)
 
 If everything was configured correctly and all ticks are green on the "config" page _(aka [Cluster Screen](#3-cluster-screen))_,  
 you will now be able to `Launch` the engine from the [options panel](#33-options-panel).  
-This button will open Ethereal Engine's default location in your browser.
+This button will open iR Engine's default location in your browser.
 
 :::important
 Make sure to allow certificates as explained [here](https://etherealengine.github.io/etherealengine-docs/docs/devops_deployment/microk8s_linux#accept-invalid-certs).
 :::
 
 ## 6. Workloads
-Workloads are the k8s pods of the components of an Ethereal Engine deployment.  
+Workloads are the k8s pods of the components of an iR Engine deployment.  
 
 ![Workloads](../images/controlCenter/workloads-screen.jpg)
 
@@ -372,7 +372,7 @@ Beside these icons there is also a container drop down through which user can se
 
 ![Admin Dashboard](../images/controlCenter/admin-dashboard.jpg)
 
-Once, everything is configured correctly and all ticks are green on config page ([Cluster Screen](#3-cluster-screen)) then you can click on `Admin` button in [navbar](#32-navbar). This will show the admin dashboard of ethereal engine deployed in your local k8s cluster.
+Once, everything is configured correctly and all ticks are green on config page ([Cluster Screen](#3-cluster-screen)) then you can click on `Admin` button in [navbar](#32-navbar). This will show the admin dashboard of iR Engine deployed in your local k8s cluster.
 
 You can perform various actions from admin dashboard including installing projects, managing users, groups, locations, instances, resources, etc.
 

--- a/docs/manual/01_install/050_advanced/07_troubleshooting.md
+++ b/docs/manual/01_install/050_advanced/07_troubleshooting.md
@@ -4,7 +4,7 @@
 `p key` debug colliders view
 
 ### Invalid Certificate errors in local environment
-As of this writing, the cert provided in the ethereal engine package for local use is not adequately signed.  
+As of this writing, the cert provided in the iR Engine package for local use is not adequately signed.  
 Browsers will throw up warnings about going to insecure pages.  
 You should be able to tell the browser to ignore it, usually by clicking on some sort of 'advanced options' button or link and then something along the lines of 'go there anyway'.
 

--- a/docs/manual/01_install/050_advanced/09_elasticKibana.md
+++ b/docs/manual/01_install/050_advanced/09_elasticKibana.md
@@ -2,6 +2,6 @@ import AcceptCertificates from '../../_partials/acceptCertificates.md'
 
 # Setup Elastic Search & Kibana
 
-Elastic Search and Kibana will be automatically launched with `npm run dev` and will be running on `localhost` ports `9200` & `5601` respectively. This will automatically set up and run Redis/MariaDB docker containers, and Ethereal Engine client/server/instance-server instances.
+Elastic Search and Kibana will be automatically launched with `npm run dev` and will be running on `localhost` ports `9200` & `5601` respectively. This will automatically set up and run Redis/MariaDB docker containers, and iR Engine client/server/instance-server instances.
 
 <AcceptCertificates />

--- a/docs/manual/01_install/050_advanced/index.md
+++ b/docs/manual/01_install/050_advanced/index.md
@@ -2,8 +2,8 @@ import AcceptCertificates from '../../_partials/acceptCertificates.md'
 
 # Advanced Setup
 
-The advanced setup is recommended for users who want to understand the internals of how the Ethereal Engine's deployment stack works.
-These instructions will explain how to manually setup Ethereal Engine docker instances, client, server and/or instance-server.  
+The advanced setup is recommended for users who want to understand the internals of how the iR Engine's deployment stack works.
+These instructions will explain how to manually setup iR Engine docker instances, client, server and/or instance-server.  
 
 ## 1. Install dependencies
 ```bash
@@ -15,7 +15,7 @@ _Note how you don't need to use sudo for any of these commands._
 > If you find errors with mediasoup:
 > - Follow the [Mediasoup Installation](https://mediasoup.org/documentation/v3/mediasoup/installation/) instructions
 > - Check that your version of python is up to date: `python --version`
-> - Make sure that the path where you installed Ethereal Engine has no whitespaces
+> - Make sure that the path where you installed iR Engine has no whitespaces
 
 ## 2. Start the MySQL database
 Make sure you have a MySQL database installed and running. Our recommendation is `MariaDB`.

--- a/docs/manual/02_concepts/01_projects.md
+++ b/docs/manual/02_concepts/01_projects.md
@@ -29,7 +29,7 @@ Projects have a few conventions.
 - `sceneName.thumbnail.png` is an auto-generated scene thumbnail file
 - `xrengine.config.ts` the project configuration, where client routes, database models, feathers services and the project thumbnail can be defined
 
-A project must also have a package.json to provide custom dependencies, and to define the project name, project version, and Ethereal Engine version it is known to work with.
+A project must also have a package.json to provide custom dependencies, and to define the project name, project version, and iR Engine version it is known to work with.
 
 Systems imported from a scene MUST have their filename end with `System.ts` and be in the `/src/systems` folder.
 This is to optimize vite's code-splitting bundling process, as each potentially dynamically importable file will result in a new bundle with it's own copy of all of it's import dependencies.
@@ -38,7 +38,7 @@ This is to optimize vite's code-splitting bundling process, as each potentially 
 If so, they should be defined in `peerDependencies` and kept up to date with the current engine version.
 
 ## Config
-The ethereal engine config file has the following options:
+The iR Engine config file has the following options:
 
 ```ts
 export interface ProjectConfigInterface {
@@ -82,7 +82,7 @@ export interface ProjectEventHooks {
 
 These functions are called when the project they belong to are installed, 
 updated (such as scenes saved) or uninstalled respectively. This is used in the 
-default ethereal engine project to install the default avatars. 
+default iR Engine project to install the default avatars. 
 See `/packages/projects/default-project/projectEventHooks.ts`.
 
 ### Thumbnail

--- a/docs/manual/02_concepts/03_locations.md
+++ b/docs/manual/02_concepts/03_locations.md
@@ -15,7 +15,7 @@ Media instances can be tied to a location, or exist ephemerally as a group call 
 Instances can also be customised with the `matchmaker` functionality to create private rooms.
 
 Locations can be loaded via the `/location/<locationName>` route, where `locationName` is the name of the location.
-Ethereal Engine always adds locations `default`, `apartment` and `sky-station` by default to new projects.
+iR Engine always adds locations `default`, `apartment` and `sky-station` by default to new projects.
 
 Adding a new location is done from the `/admin/locations` route, and live instances can be viewed from `/admin/instances`.
 

--- a/docs/manual/02_concepts/index.md
+++ b/docs/manual/02_concepts/index.md
@@ -1,6 +1,6 @@
 import DocCardList from '@theme/DocCardList'
 
 # Concepts 
-In this section you will learn how to use Ethereal Engine.  
+In this section you will learn how to use iR Engine.  
 
 <DocCardList />

--- a/docs/manual/02_scene/01_studio/01_overview/08_profile.md
+++ b/docs/manual/02_scene/01_studio/01_overview/08_profile.md
@@ -4,7 +4,7 @@ sidebar_label: "User Profile"
 import StudioOverview from './_studio_overview.md'
 
 # 8. User Profile
-Your Ethereal Engine account settings and linked account information
+Your iR Engine account settings and linked account information
 The settings wheel icon allows you to turn up your scene resolution.
 If you notice the scene looks blurry, go to the Graphics tab inside Settings and turn the Resolution tab all the way up.
 

--- a/docs/manual/02_scene/01_studio/01_overview/index.md
+++ b/docs/manual/02_scene/01_studio/01_overview/index.md
@@ -3,7 +3,7 @@ import StudioOverview from './_studio_overview.md'
 
 # Studio Overview
 
-Navigating to the `/studio` route in any Ethereal Engine deployment will show you the projects page, where you can open existing projects or create a new one.  
+Navigating to the `/studio` route in any iR Engine deployment will show you the projects page, where you can open existing projects or create a new one.  
 > _eg: When the engine is hosted at `dev.etherealengine.com`, the studio would be accessed from `dev.etherealengine.com/studio`_
 
 Opening a project will open the editor, from which you can then load any scenes contained in your project.

--- a/docs/manual/02_scene/02_visualscript/index.md
+++ b/docs/manual/02_scene/02_visualscript/index.md
@@ -8,10 +8,10 @@ Widely embraced for implementing visual scripting languages, behavior graphs hav
 Notable examples include Unreal Engine's Blueprints, Unity's Visual Scripting, and NVIDIA Omniverse's OmniGraph.
 These engines leverage behavior graphs to empower game designers and developers in crafting sophisticated behaviors without delving into direct code writing.
 
-In the context of Ethereal Engine, Behavior Graphs hold a pivotal role by offering a visual scripting interface to the engine.
+In the context of iR Engine, Behavior Graphs hold a pivotal role by offering a visual scripting interface to the engine.
 It provides seamless interaction with the engine, facilitating the modeling, organization, control, and assignment of intricate behaviors to entities with unparalleled ease.
 
 ## Audience
 VisualScript is designed for developers, designers, artists, and non-technical users.
 This visual scripting feature streamlines the implementation of complex logic and actions for entities without script writing.
-It promotes collaboration and empowers a diverse range of individuals to craft immersive experiences and interactive content for Ethereal Engine.
+It promotes collaboration and empowers a diverse range of individuals to craft immersive experiences and interactive content for iR Engine.

--- a/docs/manual/02_scene/05_management/index.md
+++ b/docs/manual/02_scene/05_management/index.md
@@ -23,7 +23,7 @@ In the File menu, click the save or save as button to save your scene.
 Some projects require time to save so don't exit this window until a few minutes have passed.
 
 ## Editing Materials
-Ethereal Engine supports PBR workflow and Vertex Colors. The material properties supported are:
+iR Engine supports PBR workflow and Vertex Colors. The material properties supported are:
 - Diffuse or Base Color Map
 - Metalness Map
 - Roughness Map

--- a/docs/manual/03_modules/01_engine/04_ecs.md
+++ b/docs/manual/03_modules/01_engine/04_ecs.md
@@ -44,7 +44,7 @@ const TransformComponent = defineComponent({
 ```
 
 ### Array of Structures: Reactive Component Data
-Reactive Component Data is an implementation unique to Ethereal Engine, using `React` and `Hookstate` under the hood.  
+Reactive Component Data is an implementation unique to iR Engine, using `React` and `Hookstate` under the hood.  
 
 Its key benefits are:
 - It allows for reactive data binding.  
@@ -110,7 +110,7 @@ export const TimerSystem = defineSystem({
 
 ```
 
-This example uses the _`Array of Structures`_ Reactive Component Data syntax, from Ethereal Engine, which allows for reactive data binding.
+This example uses the _`Array of Structures`_ Reactive Component Data syntax, from iR Engine, which allows for reactive data binding.
 ```ts
 const TimerComponent = defineComponent({
   name: 'TimerComponent',
@@ -149,4 +149,4 @@ export const TimerSystem = defineSystem({
 ## References
 - [Entity Component System Overview in 7 Minutes](https://www.youtube.com/watch?v=2rW7ALyHaas)
 - [Entity Component System in TypeScript with Phaser 3 and bitECS)](https://www.youtube.com/watch?v=BVIiAO5-2-Y)
-- [Overwatch GDC ECS & Netcode](https://www.youtube.com/watch?v=W3aieHjyNvw) (note, ethereal engine does not use this style of networking)
+- [Overwatch GDC ECS & Netcode](https://www.youtube.com/watch?v=W3aieHjyNvw) (note, iR Engine does not use this style of networking)

--- a/docs/manual/03_modules/01_engine/05_networking.md
+++ b/docs/manual/03_modules/01_engine/05_networking.md
@@ -7,7 +7,7 @@ There are two types of networks:
 - **media** networks -> tied to media instances
 
 ## Users & Peers
-Users are unique accounts created in a particular Ethereal Engine deployment.  
+Users are unique accounts created in a particular iR Engine deployment.  
 Users can connect to multiple instances, and have multiple peers connected to each instance.  
 Only a single avatar will be loaded for a user, but this avatar can be controlled by any of that user's peers.
 

--- a/docs/manual/03_modules/01_engine/08_debugging/index.md
+++ b/docs/manual/03_modules/01_engine/08_debugging/index.md
@@ -1,6 +1,6 @@
 import DocCardList from '@theme/DocCardList'
 
 # Debugging
-This section covers different techniques for debugging Ethereal Engine's source code and any projects created with it.
+This section covers different techniques for debugging iR Engine's source code and any projects created with it.
 
 <DocCardList />

--- a/docs/manual/03_modules/03_world/03_assets/index.md
+++ b/docs/manual/03_modules/03_world/03_assets/index.md
@@ -15,7 +15,7 @@ The simplest pipeline uses Blender & the Studio's inbuilt transformation tool.
 Scenes that contain colliders should have these colliders exported separately.
 Visible meshes should not have collider metadata, instead a copy should be created.
 
-The process of moving from Blender to Ethereal Engine looks like the following:
+The process of moving from Blender to iR Engine looks like the following:
 
 1. Blend file is the source of truth
 2. Export visible meshes from from blend file

--- a/docs/manual/03_modules/05_infrastructure/02_adminPanel/01_dashboard.md
+++ b/docs/manual/03_modules/05_infrastructure/02_adminPanel/01_dashboard.md
@@ -1,5 +1,5 @@
 # Dashboard
-The Admin Panel Dashboard provides an overview of several performance indicators relevant to an Ethereal Engine's deployment.  
+The Admin Panel Dashboard provides an overview of several performance indicators relevant to an iR Engine's deployment.  
 It gives a progress report for how a deployment is performing over a certain period of time based on data captured during the selected period.
 
 ![](./images/dashboard.png)

--- a/docs/manual/03_modules/05_infrastructure/02_adminPanel/02_servers.md
+++ b/docs/manual/03_modules/05_infrastructure/02_adminPanel/02_servers.md
@@ -1,5 +1,5 @@
 # Servers
-The Servers page provides a list of all of the servers running in an Ethereal Engine's deployment.
+The Servers page provides a list of all of the servers running in an iR Engine's deployment.
 
 ![](./images/servers.png)
 _Note: The labels at the top of the page will filter servers by category when clicked._

--- a/docs/manual/03_modules/05_infrastructure/02_adminPanel/03_projects.md
+++ b/docs/manual/03_modules/05_infrastructure/02_adminPanel/03_projects.md
@@ -1,6 +1,6 @@
 # Projects
 <!-- TODO: Confirm that the information given in this section is correct. -->
-The Projects page provides a tool to add new projects and list all existing projects of an Ethereal Engine's deployment.
+The Projects page provides a tool to add new projects and list all existing projects of an iR Engine's deployment.
 
 ![](./images/projects/list.png)
 

--- a/docs/manual/03_modules/05_infrastructure/02_adminPanel/05_locations.md
+++ b/docs/manual/03_modules/05_infrastructure/02_adminPanel/05_locations.md
@@ -1,5 +1,5 @@
 # Locations
-The Locations page provides a tool to add new locations and list all existing locations of an Ethereal Engine's deployment.
+The Locations page provides a tool to add new locations and list all existing locations of an iR Engine's deployment.
 
 ![](./images/locations/list.png)
 ## Location Table

--- a/docs/manual/03_modules/05_infrastructure/02_adminPanel/07_avatars.md
+++ b/docs/manual/03_modules/05_infrastructure/02_adminPanel/07_avatars.md
@@ -1,5 +1,5 @@
 # Avatars
-The Avatars page provides a tool to view, upload and manage all of the Avatar files stored in the Ethereal Engine deployment.
+The Avatars page provides a tool to view, upload and manage all of the Avatar files stored in the iR Engine deployment.
 
 ![](./images/avatars/list.png)
 ## Avatar Table

--- a/docs/manual/03_modules/05_infrastructure/02_adminPanel/09_bots.md
+++ b/docs/manual/03_modules/05_infrastructure/02_adminPanel/09_bots.md
@@ -1,6 +1,6 @@
 # Bots
 <!-- TODO: Explain what this page is for -->
-The Bots page provides a tool to view and manage the bots of an Ethereal Engine deployment.
+The Bots page provides a tool to view and manage the bots of an iR Engine deployment.
 ## Create a new Bot
 - **Name**:  .
 - **Description**:  .

--- a/docs/manual/03_modules/05_infrastructure/02_adminPanel/10_channels.md
+++ b/docs/manual/03_modules/05_infrastructure/02_adminPanel/10_channels.md
@@ -1,7 +1,7 @@
 # Channels
-The Channels page provides list of the active text/audio/video channels available in an Ethereal Engine deployment.
+The Channels page provides list of the active text/audio/video channels available in an iR Engine deployment.
 
-Ethereal Engine channels are very similar in concept to Discord channels.  
+iR Engine channels are very similar in concept to Discord channels.  
 They allow for communication between the users of a deployment via text, audio or video chat.
 
 - **ID**: Unique ID of the Channel.

--- a/docs/manual/03_modules/05_infrastructure/02_adminPanel/11_invites.md
+++ b/docs/manual/03_modules/05_infrastructure/02_adminPanel/11_invites.md
@@ -1,5 +1,5 @@
 # Invites
-The Invites page provides a tool to generate and manage invite links to the Ethereal Engine deployment.
+The Invites page provides a tool to generate and manage invite links to the iR Engine deployment.
 - **ID**: Unique ID of the Invite.
 - **Name**: Human-readable name of the Invite.
 - **Passcode**: .  <!-- TODO: What is this for? -->

--- a/docs/manual/03_modules/05_infrastructure/02_adminPanel/12_recordings.md
+++ b/docs/manual/03_modules/05_infrastructure/02_adminPanel/12_recordings.md
@@ -1,5 +1,5 @@
 # Recordings
-This page provides a tool to manage the Motion Capture (Mocap) recordings of the Ethereal Engine deployment.
+This page provides a tool to manage the Motion Capture (Mocap) recordings of the iR Engine deployment.
 
 ![](./images/recordings/list.png)
 

--- a/docs/manual/03_modules/05_infrastructure/02_adminPanel/13_resources.md
+++ b/docs/manual/03_modules/05_infrastructure/02_adminPanel/13_resources.md
@@ -1,5 +1,5 @@
 # Resources
-The Resources page provides a tool to list and manage all of the Asset files of the Ethereal Engine deployment.
+The Resources page provides a tool to list and manage all of the Asset files of the iR Engine deployment.
 
 ![](./images/resources/list.png)
 - **Id**: Unique ID of the Asset/Resource file.

--- a/docs/manual/03_modules/05_infrastructure/02_adminPanel/15_users.md
+++ b/docs/manual/03_modules/05_infrastructure/02_adminPanel/15_users.md
@@ -3,7 +3,7 @@
 - **User ID**: Unique ID of the selected User.
 - **Name**: Human-readable name of the selected User. Could contain a #NUMBER postfix to differentiate its name from other users with the same name. _(eg: Guest#234)_
 - **Avatar**: Unique ID of the avatar that the selected User is currently using.
-- **Linked Accounts**: Which external OAuth accounts the selected user has connected to his iR Engine deployment account.
+- **Linked Accounts**: Which external OAuth accounts the selected user has connected to their iR Engine deployment account.
 - **Is Guest**: Whether the selected User is a Guest or Registered.
 - **Invite Code**: Currently active invite code of the selected User.
 - **Action**:  

--- a/docs/manual/03_modules/05_infrastructure/02_adminPanel/15_users.md
+++ b/docs/manual/03_modules/05_infrastructure/02_adminPanel/15_users.md
@@ -3,7 +3,7 @@
 - **User ID**: Unique ID of the selected User.
 - **Name**: Human-readable name of the selected User. Could contain a #NUMBER postfix to differentiate its name from other users with the same name. _(eg: Guest#234)_
 - **Avatar**: Unique ID of the avatar that the selected User is currently using.
-- **Linked Accounts**: Which external OAuth accounts the selected user has connected to his Ethereal Engine deployment account.
+- **Linked Accounts**: Which external OAuth accounts the selected user has connected to his iR Engine deployment account.
 - **Is Guest**: Whether the selected User is a Guest or Registered.
 - **Invite Code**: Currently active invite code of the selected User.
 - **Action**:  
@@ -19,7 +19,7 @@
 - **Benchmarking: read/write**: .
 - **Bot: read/write**: .
 - **contentPacks: read/write**: .
-- **Editor: write**: Provides access for the Ethereal Engine Studio editor to the selected User.
+- **Editor: write**: Provides access for the iR Engine Studio editor to the selected User.
 - **globalAvatars: read/write**: .
 - **Groups: read/write**: .
 - **Instance: read/write**: .

--- a/docs/manual/03_modules/05_infrastructure/02_adminPanel/index.md
+++ b/docs/manual/03_modules/05_infrastructure/02_adminPanel/index.md
@@ -5,7 +5,7 @@ sidebar_label: Admin Panel
 import DocCardList from '@theme/DocCardList'
 
 # Admin Panel Overview
-The Ethereal Engine's `Admin Panel` is a graphical interface (GUI) tool for managing administration tasks of an Ethereal Engine deployment.
+The iR Engine's `Admin Panel` is a graphical interface (GUI) tool for managing administration tasks of an iR Engine deployment.
 
 The Admin Panel can be accessed by navigating to the `/admin` route of the desired deployment.  
 _eg: `https://localhost:3000/admin` when working with a local deployment_

--- a/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/01_microk8s_linux.md
+++ b/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/01_microk8s_linux.md
@@ -2,7 +2,7 @@ import AcceptCertificates from '../../../_partials/acceptCertificates.md'
 import PythonUbuntu from '../../../_partials/pythonUbuntu.md'
 import MakeUbuntu from '../../../_partials/makeUbuntu.md'
 
-# Ethereal Engine on MicroK8s (Linux)
+# iR Engine on MicroK8s (Linux)
 
 This guide has been tested on Ubuntu, and it is intended for local deployment only.
 
@@ -23,17 +23,17 @@ sudo snap install microk8s --classic --channel=1.26/stable
 
 Another alternative is to follow the instructions for how to [install Kubernetes with MicroK8s](https://ubuntu.com/tutorials/install-a-local-kubernetes-with-microk8s#1-overview) in a local environment. This will help you learn more about how MicroK8s deployment works.  
 
-## Download Ethereal Engine
-To build the Ethereal Engine Docker image locally, and to have a pre-tested way to run various local services, you'll need to download the Ethereal Engine repository to your device. The easiest way to do this is by running the following command in your Ubuntu terminal:
+## Download iR Engine
+To build the iR Engine Docker image locally, and to have a pre-tested way to run various local services, you'll need to download the iR Engine repository to your device. The easiest way to do this is by running the following command in your Ubuntu terminal:
 ```bash
 git clone https://github.com/etherealengine/etherealengine.git
 ```
-You can create an `.env.local` file by duplicating `.env.local.default` if it does not already exist in the root folder of Ethereal Engine's repository.
+You can create an `.env.local` file by duplicating `.env.local.default` if it does not already exist in the root folder of iR Engine's repository.
 
 ## Start MinIO & MariaDB
 We recommend running MinIO & MariaDB server on your local machine via Docker and outside of MicroK8s.
 
-Running the command `docker-compose up` from the top-level `/scripts` directory of the Ethereal Engine repository will also start MinIO and multiple MariaDB docker containers _(as well as an optional redis server)_:
+Running the command `docker-compose up` from the top-level `/scripts` directory of the iR Engine repository will also start MinIO and multiple MariaDB docker containers _(as well as an optional redis server)_:
 1. Port **3306**: Server for local development
 2. Port **3305**: Server for automated testing
 3. Port **3304**: Server for minikube/microk8s testing
@@ -142,7 +142,7 @@ Add or update the following line into your `/etc/hosts` file:
 > On Linux this can be done by running `sudo gedit /etc/hosts`  
 > Make sure to save the file after editing. You will need administrator permissions to do so.
 
-This will redirect several `*-local.etherealengine.org` domains internally to the host machine. `nginx` ingress server will now be able to redirect the traffic to the appropriate Ethereal Engine pod.
+This will redirect several `*-local.etherealengine.org` domains internally to the host machine. `nginx` ingress server will now be able to redirect the traffic to the appropriate iR Engine pod.
 
 ## Add Helm repositories
 You'll need to add a few Helm chart repositories. You can do so by running the following commands:
@@ -151,7 +151,7 @@ helm repo add agones https://agones.dev/chart/stable
 helm repo add redis https://charts.bitnami.com/bitnami
 helm repo add etherealengine https://helm.etherealengine.org
 ```
-This will add the Helm charts for Agones, Redis and Ethereal Engine, respectively.
+This will add the Helm charts for Agones, Redis and iR Engine, respectively.
 
 ## Install Agones and Redis deployments
 From here on, deployments will be installed using Helm repositories.
@@ -168,7 +168,7 @@ kubectl config get-contexts
 ```
 > The current context will have a `*` under the left-most `current` column.
 
-Once kubectl is pointed to MicroK8s, run these commands from the top of the Ethereal Engine repo to install Agones and Redis:  
+Once kubectl is pointed to MicroK8s, run these commands from the top of the iR Engine repo to install Agones and Redis:  
 ```bash
 helm install -f </path/to/agones-default-values.yaml> agones agones/agones
 helm install local-redis redis/redis
@@ -233,7 +233,7 @@ http://<username>:<password>@<host>:<port>
 > The file [local.microk8s.template.values.yaml](https://github.com/EtherealEngine/ethereal-engine-ops/blob/master/configs/local.microk8s.template.values.yaml) can be found in the [ethereal-engine-ops](https://github.com/EtherealEngine/ethereal-engine-ops) repo.
 
 ## Build MicroK8s
-Run the following command from the root of the Ethereal Engine repository after MicroK8s is running:
+Run the following command from the root of the iR Engine repository after MicroK8s is running:
 ```bash
 ./scripts/build_microk8s.sh
 ```
@@ -245,7 +245,7 @@ Run the following command from the root of the Ethereal Engine repository after 
 > npx ts-node --swc scripts/install-projects.js
 > ```
 
-This _build_microK8s_ script will build an image of the entire Ethereal Engine repository into a single Docker file.
+This _build_microK8s_ script will build an image of the entire iR Engine repository into a single Docker file.
 
 Vite builds the client files using some information from the MariaDB database created for MicroK8s deployments to fill in some variables, and it needs database credentials.  
 The script will supply default values for all of the `MYSQL_*` variables if they are not provided to the script, as well as `VITE_CLIENT_HOST`, `VITE_SERVER_HOST`, and `VITE_INSTANCESERVER_HOST`.
@@ -266,9 +266,9 @@ There is a [template](https://github.com/EtherealEngine/ethereal-engine-ops/blob
 
 If you are using a local file server, as explained in one of the previous steps, you will need to update the variable `api.fileServer.hostUploadFolder` in the `local.values.yaml` file with a value similar to `ENGINE_FULL_PATH/packages/server/upload`.  
 _e.g. `/home/username/etherealengine/packages/server/upload`._  
-It is mandatory that it points to the `/packages/server/upload` folder of your Ethereal Engine folder.
+It is mandatory that it points to the `/packages/server/upload` folder of your iR Engine folder.
 
-## Deploy Ethereal Engine Helm chart
+## Deploy iR Engine Helm chart
 Run the following command:
 ```bash
 helm install -f </path/to/local.values.yaml> -f </path/to/db-refresh-true.values.yaml> local etherealengine/etherealengine

--- a/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/01_microk8s_windows.md
+++ b/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/01_microk8s_windows.md
@@ -1,6 +1,6 @@
 import AcceptCertificates from './_acceptCertificates.md'
 
-# Ethereal Engine on MicroK8s (Windows)
+# iR Engine on MicroK8s (Windows)
 
 This guide is intended for local environment and currently tested on Windows 11.
 
@@ -134,9 +134,9 @@ sudo snap install microk8s --classic --channel=1.26/stable
 
 While you can follow the demo instructions there about starting MicroK8s, deploying some demo deployments, etc. to get a feel for it.
 
-## Clone Ethereal Engine repo to your local machine
+## Clone iR Engine repo to your local machine
 
-To build the Ethereal Engine Docker image locally, and to have a pre-tested way to run various local services, you'll need to get the Ethereal Engine repo on your machine. This is most easily done by running following command in WSL Ubuntu terminal.
+To build the iR Engine Docker image locally, and to have a pre-tested way to run various local services, you'll need to get the iR Engine repo on your machine. This is most easily done by running following command in WSL Ubuntu terminal.
 
 ```bash
 git clone https://github.com/etherealengine/etherealengine.git etherealengine
@@ -148,7 +148,7 @@ If `.env.local` file does not exist in the root of your repo folder then create 
 
 For simplicity, we recommend running MinIO & MariaDB server on your local machine outside of MicroK8s.
 
-If you run `docker-compose up` from the top-level `/scripts` directory in the Ethereal Engine repo, it will start up MinIO & multiple MariaDB docker containers (as well as a redis server, which is not needed). For mariadb containers, one is intended for local development, runs on port 3306; another, intended for automated testing purposes, runs on port 3305; and the last one, intended for minikube/microk8s testing, runs on port 3304. Once the docker container is stopped, you can start it again by running `npm run dev-docker`.
+If you run `docker-compose up` from the top-level `/scripts` directory in the iR Engine repo, it will start up MinIO & multiple MariaDB docker containers (as well as a redis server, which is not needed). For mariadb containers, one is intended for local development, runs on port 3306; another, intended for automated testing purposes, runs on port 3305; and the last one, intended for minikube/microk8s testing, runs on port 3304. Once the docker container is stopped, you can start it again by running `npm run dev-docker`.
 
 Alternatively, if you want to just run MinIO & MariaDB on its own without Docker, that's fine too. You'll just have to configure the Helm config file to have the appropriate S3 & SQL server configuration, and possibly change the script `./scripts/build_microk8s.sh`.
 
@@ -267,7 +267,7 @@ helm repo add redis https://charts.bitnami.com/bitnami
 helm repo add etherealengine https://helm.etherealengine.org
 ```
 
-This will add the Helm charts for Agones, Redis, and Ethereal Engine, respectively.
+This will add the Helm charts for Agones, Redis, and iR Engine, respectively.
 
 ## Install Agones and Redis deployments
 
@@ -276,7 +276,7 @@ After adding those Helm repos, you'll start installing deployments using Helm re
 Make sure that kubectl is pointed at MicroK8s by running `kubectl config current-context`, which should say 'microk8s'. You can also run `kubectl config get-contexts` to get all contexts that kubectl has been configured to run; the current one will have a '*' under the left-most
 'current' column.
 
-Once kubectl is pointed to microk8s, from the top of the Ethereal Engine repo, run `helm install -f </path/to/agones-default-values.yaml> agones agones/agones` to install Agones and `helm install local-redis redis/redis` to install redis.
+Once kubectl is pointed to microk8s, from the top of the iR Engine repo, run `helm install -f </path/to/agones-default-values.yaml> agones agones/agones` to install Agones and `helm install local-redis redis/redis` to install redis.
 
 > [agones-default-values.yaml](https://github.com/EtherealEngine/ethereal-engine-ops/blob/master/configs/agones-default-values.yaml) can be found in [ethereal-engine-ops](https://github.com/EtherealEngine/ethereal-engine-ops) repo.
 
@@ -312,7 +312,7 @@ In order to connect logger with elasticsearch, update `local.microk8s.template.v
 
 ## Run build_microk8s.sh
 
-When microk8s is running, run the following command from the root of the Ethereal Engine repo in WSL Ubuntu terminal:
+When microk8s is running, run the following command from the root of the iR Engine repo in WSL Ubuntu terminal:
 
 ```bash
 export REGISTRY_HOST=microk8s.registry; export MYSQL_HOST=kubernetes.docker.internal;bash ./scripts/build_microk8s.sh
@@ -329,7 +329,7 @@ npx ts-node --swc scripts/install-projects.js
 
 The script builds the full-repo Docker image using several build arguments. Vite, which builds he client files, uses some information from the MariaDB database created for microk8s deployments to fill in some variables, and needs database credentials. The script will supply default values for all of the MYSQL_* variables if they are not provided to the script, as well as VITE_CLIENT_HOST, VITE_SERVER_HOST, and VITE_INSTANCESERVER_HOST. The latter three will make your microk8s deployment accessible on `(local/api-local/instanceserver-local).etherealengine.org`; if you want to run it on a different domain, then you'll have to set those three environment variables to what you want them to be (and also change the hostfile records you made pointing those subdomains)
 
-This will build an image of the entire Ethereal Engine repo into a single Docker file. When deployed for different services, it will only run the parts needed for that service. This may take up to 15 minutes, though later builds should take less time as things are cached.
+This will build an image of the entire iR Engine repo into a single Docker file. When deployed for different services, it will only run the parts needed for that service. This may take up to 15 minutes, though later builds should take less time as things are cached.
 
 Once the images are build. It will push it to MicroK8s local registry. You can verify that images are pushed to registry by visiting [http://microk8s.registry:32000/v2/_catalog](http://microk8s.registry:32000/v2/_catalog).
 
@@ -340,7 +340,7 @@ a [template](https://github.com/EtherealEngine/ethereal-engine-ops/blob/master/c
 
 If you are using local file server as explained couple of steps earlier then, update 'local.values.yaml' variable `api.fileServer.hostUploadFolder` with value similar to '\<ENGINE_FULL_PATH\>/packages/server/upload' e.g. '/home/\<OS_USER_NAME\>/\<ENGINE_FOLDER\>/packages/server/upload'. Its mandatory to point to `/packages/server/upload` folder of your engine folder.
 
-## Deploy Ethereal Engine Helm chart
+## Deploy iR Engine Helm chart
 
 Before this step, ensure that all the agones and redis pods are in "Running" state. You can check pods status using the below command.
 

--- a/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/02_dockerDesktop.md
+++ b/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/02_dockerDesktop.md
@@ -1,6 +1,6 @@
 import AcceptCertificates from './_acceptCertificates.md'
 
-# Ethereal Engine on Docker Desktop
+# iR Engine on Docker Desktop
 **NOTE**: _UDP networking does not work properly on Docker Desktop as of this writing, as Docker Desktop does not expose the IP addresses/ports of the node publicly, so mediasoup cannot connect over UDP. If you want to test audio/video calling or networked movements, please use minikube._
 
 ## Install kubectl, Helm, and Docker Desktop
@@ -8,16 +8,16 @@ If [kubectl](https://kubernetes.io/docs/tasks/tools/), [Helm](https://helm.sh/do
 
 You may also need to install [Docker Compose](https://docs.docker.com/compose/install/)
 
-## Clone Ethereal Engine repo to your local machine
-To build the Ethereal Engine Docker image locally, and to have a pre-tested way to run various local
-services, you'll need to get the Ethereal Engine repo on your machine. This is most easily
+## Clone iR Engine repo to your local machine
+To build the iR Engine Docker image locally, and to have a pre-tested way to run various local
+services, you'll need to get the iR Engine repo on your machine. This is most easily
 done by running `git clone https://github.com/etherealengine/etherealengine.git`
 
 ## Start MinIO & MariaDB server locally via Docker
 
 For simplicity, we recommend running MinIO & MariaDB server on your local machine outside of MicroK8s.
 
-If you run `docker-compose up` from the top-level `/scripts` directory in the Ethereal Engine repo, it will start up MinIO & multiple MariaDB docker containers (as well as a redis server, which is not needed). For mariadb containers, one is intended for local development, runs on port 3306; another, intended for automated testing purposes, runs on port 3305; and the last one, intended for minikube/microk8s testing, runs on port 3304. Once the docker container is stopped, you can start it again by running `npm run dev-docker`.
+If you run `docker-compose up` from the top-level `/scripts` directory in the iR Engine repo, it will start up MinIO & multiple MariaDB docker containers (as well as a redis server, which is not needed). For mariadb containers, one is intended for local development, runs on port 3306; another, intended for automated testing purposes, runs on port 3305; and the last one, intended for minikube/microk8s testing, runs on port 3304. Once the docker container is stopped, you can start it again by running `npm run dev-docker`.
 
 Alternatively, if you want to just run MinIO & MariaDB on its own without Docker, that's fine too. You'll just have to configure the Helm config file to have the appropriate S3 & SQL server configuration, and possibly change the script `./scripts/build_minikube.sh`.
 
@@ -63,7 +63,7 @@ helm repo add redis https://charts.bitnami.com/bitnami
 helm repo add etherealengine https://helm.etherealengine.org
 ```
 
-This will add the Helm charts for Agones, Redis, and Ethereal Engine, respectively.
+This will add the Helm charts for Agones, Redis, and iR Engine, respectively.
 
 ## Install Agones and Redis deployments
 After adding those Helm repos, you'll start installing deployments using Helm repos.
@@ -73,7 +73,7 @@ which should say 'docker-desktop'. You can also run `kubectl config get-contexts
 that kubectl has been configured to run; the current one will have a '*' under the left-most
 'current' column.
 
-Once kubectl is pointed to docker-desktop, from the top of the Ethereal Engine repo, run
+Once kubectl is pointed to docker-desktop, from the top of the iR Engine repo, run
 `helm install -f </path/to/agones-default-values.yaml> agones agones/agones` to install Agones
 and `helm install local-redis redis/redis` to install redis.
 
@@ -83,7 +83,7 @@ You can run `kubectl get pods -A` to list all of the pods running in docker-desk
 all of these pods should be in the Running state.
 
 ## Run build_docker_desktop.sh
-When docker desktop's Kubernetes cluster is running, run the following command from the root of the Ethereal Engine repo:
+When docker desktop's Kubernetes cluster is running, run the following command from the root of the iR Engine repo:
 
 ```bash
 ./scripts/build_docker_desktop.sh
@@ -107,7 +107,7 @@ accessible on `(local/api-local/instanceserver-local).etherealengine.org`; if yo
 domain, then you'll have to set those three environment variables to what you want them to be (and also
 change the hostfile records you made pointing those subdomains to 127.0.0.1)
 
-This will build an image of the entire Ethereal Engine repo into a single Docker file. When deployed for
+This will build an image of the entire iR Engine repo into a single Docker file. When deployed for
 different services, it will only run the parts needed for that service. This may take up to 15 minutes,
 though later builds should take less time as things are cached.
 
@@ -118,7 +118,7 @@ a [template](https://github.com/EtherealEngine/ethereal-engine-ops/blob/master/c
 
 If you are using local file server as explained a couple of steps earlier then, update 'local.values.yaml' variable `api.fileServer.hostUploadFolder` with value e.g. '/hosthome/\<OS_USER_NAME\>/\<ENGINE_FOLDER\>/packages/server/upload'. The folder must be in home folder and make sure to use /hosthome/ instead of home in path. It's mandatory to point to `/packages/server/upload` folder of your engine folder.
 
-## Deploy Ethereal Engine Helm chart
+## Deploy iR Engine Helm chart
 Run the following command: `helm install -f </path/to/local.values.yaml> -f </path/to/db-refresh-true.values.yaml> local etherealengine/etherealengine`.
 
 > [db-refresh-true.values.yaml](https://github.com/EtherealEngine/ethereal-engine-ops/blob/master/configs/db-refresh-true.values.yaml) can be found in [ethereal-engine-ops](https://github.com/EtherealEngine/ethereal-engine-ops) repo.

--- a/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/02_minikube.md
+++ b/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/02_minikube.md
@@ -1,6 +1,6 @@
 import AcceptCertificates from './_acceptCertificates.md'
 
-# Ethereal Engine on Minikube
+# iR Engine on Minikube
 
 ## Install kubectl, Helm, Docker, and VirtualBox
 If [kubectl](https://kubernetes.io/docs/tasks/tools/), [Helm](https://helm.sh/docs/intro/install/),
@@ -13,19 +13,19 @@ You may also need to install [Docker Compose](https://docs.docker.com/compose/in
 Instructions can be found [here](https://minikube.sigs.k8s.io/docs/start/)
 
 While you can follow the demo instructions there about starting minikube, deploying
-some demo deployments, etc. to get a feel for it, before deploying Ethereal Engine you should delete
+some demo deployments, etc. to get a feel for it, before deploying iR Engine you should delete
 your minikube cluster, since we have some specific starting requirements.
 
-## Clone Ethereal Engine repo to your local machine
-To build the Ethereal Engine Docker image locally, and to have a pre-tested way to run various local
-services, you'll need to get the Ethereal Engine repo on your machine. This is most easily
+## Clone iR Engine repo to your local machine
+To build the iR Engine Docker image locally, and to have a pre-tested way to run various local
+services, you'll need to get the iR Engine repo on your machine. This is most easily
 done by running `git clone https://github.com/etherealengine/etherealengine.git`
 
 ## Start MinIO & MariaDB server locally via Docker
 
 For simplicity, we recommend running MinIO & MariaDB server on your local machine outside of MicroK8s.
 
-If you run `docker-compose up` from the top-level `/scripts` directory in the Ethereal Engine repo, it will start up MinIO & multiple MariaDB docker containers (as well as a redis server, which is not needed). For mariadb containers, one is intended for local development, runs on port 3306; another, intended for automated testing purposes, runs on port 3305; and the last one, intended for minikube/microk8s testing, runs on port 3304. Once the docker container is stopped, you can start it again by running `npm run dev-docker`.
+If you run `docker-compose up` from the top-level `/scripts` directory in the iR Engine repo, it will start up MinIO & multiple MariaDB docker containers (as well as a redis server, which is not needed). For mariadb containers, one is intended for local development, runs on port 3306; another, intended for automated testing purposes, runs on port 3305; and the last one, intended for minikube/microk8s testing, runs on port 3304. Once the docker container is stopped, you can start it again by running `npm run dev-docker`.
 
 Alternatively, if you want to just run MinIO & MariaDB on its own without Docker, that's fine too. You'll just have to configure the Helm config file to have the appropriate S3 & SQL server configuration, and possibly change the script `./scripts/build_minikube.sh`.
 
@@ -81,7 +81,7 @@ helm repo add redis https://charts.bitnami.com/bitnami
 helm repo add etherealengine https://helm.etherealengine.org
 ```
 
-This will add the Helm charts for Agones, Redis, and Ethereal Engine, respectively.
+This will add the Helm charts for Agones, Redis, and iR Engine, respectively.
 
 ## Install Agones and Redis deployments
 After adding those Helm repos, you'll start installing deployments using Helm repos.
@@ -91,7 +91,7 @@ which should say 'minikube'. You can also run `kubectl config get-contexts` to g
 that kubectl has been configured to run; the current one will have a '*' under the left-most
 'current' column.
 
-Once kubectl is pointed to minikube, from the top of the Ethereal Engine repo, run
+Once kubectl is pointed to minikube, from the top of the iR Engine repo, run
 `helm install -f </path/to/agones-default-values.yaml> agones agones/agones` to install Agones
 and `helm install local-redis redis/redis` to install redis.
 
@@ -131,7 +131,7 @@ In order to connect logger with elasticsearch, update `local.minikube.template.v
 > [local.minikube.template.values.yaml](https://github.com/EtherealEngine/ethereal-engine-ops/blob/master/configs/local.minikube.template.values.yaml) can be found in [ethereal-engine-ops](https://github.com/EtherealEngine/ethereal-engine-ops) repo.
 
 ## Run build_minikube.sh
-When minikube is running, run the following command from the root of the Ethereal Engine repo:
+When minikube is running, run the following command from the root of the iR Engine repo:
 
 ```bash
 ./scripts/build_minikube.sh
@@ -160,7 +160,7 @@ accessible on `(local/api-local/instanceserver-local).etherealengine.org`; if yo
 domain, then you'll have to set those three environment variables to what you want them to be (and also
 change the hostfile records you made pointing those subdomains to minikube's IP)
 
-This will build an image of the entire Ethereal Engine repo into a single Docker file. When deployed for
+This will build an image of the entire iR Engine repo into a single Docker file. When deployed for
 different services, it will only run the parts needed for that service. This may take up to 15 minutes,
 though later builds should take less time as things are cached.
 
@@ -171,7 +171,7 @@ a [template](https://github.com/EtherealEngine/ethereal-engine-ops/blob/master/c
 
 If you are using local file server as explained couple of steps earlier then, update 'local.values.yaml' variable `api.fileServer.hostUploadFolder` with value e.g. '/hosthome/\<OS_USER_NAME\>/\<ENGINE_FOLDER\>/packages/server/upload'. The folder must be in home folder and make sure to use /hosthome/ instead of home in path. Its mandatory to point to `/packages/server/upload` folder of your engine folder.
 
-## Deploy Ethereal Engine Helm chart
+## Deploy iR Engine Helm chart
 Run the following command: `helm install -f </path/to/local.values.yaml> -f </path/to/db-refresh-true.values.yaml> local etherealengine/etherealengine`.
 
 > [db-refresh-true.values.yaml](https://github.com/EtherealEngine/ethereal-engine-ops/blob/master/configs/db-refresh-true.values.yaml) can be found in [ethereal-engine-ops](https://github.com/EtherealEngine/ethereal-engine-ops) repo.

--- a/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/03_AWSSetup/02_EKS.md
+++ b/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/03_AWSSetup/02_EKS.md
@@ -1,5 +1,5 @@
 ## Create EKS cluster with four nodegroups
-You first need to set up an EKS cluster for Ethereal Engine to run on.
+You first need to set up an EKS cluster for iR Engine to run on.
 While this can be done via AWS' web interface, the ```eksctl``` CLI 
 will automatically provision more of the services you need automatically,
 and is thus recommended.
@@ -30,13 +30,13 @@ If you name it something else, be sure to change the NodeAffinity in the configu
 nodegroups that will be created for various services to run on.
 
 Make sure to increase the maximum node limit, as by default target, minimum, and maximum are
-set to 2, and Ethereal Engine's setup will definitely need more than two nodes if you've configured
+set to 2, and iR Engine's setup will definitely need more than two nodes if you've configured
 them to use relatively small instance types such as t3a.medium.
 
 #### Enable EBS CSI Addon (if EKS version is 1.23 or later)
 Follow the instructions [here](https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html)
 to enable an EKS addon that's required for any cluster that will have Persistent Volumes, which an
-Ethereal Engine deployment cluster will.
+iR Engine deployment cluster will.
 
 #### Install Cluster Autoscaler (optional)
 
@@ -93,8 +93,8 @@ The default subnets should be fine, so hit Next, review everything, and click Cr
 
 #### Create nodegroup for builder
 
-The full Ethereal Engine stack needs a builder server within the cluster in order to bundle and build
-Ethereal Engine projects into the codebase that will be deployed. This should run on its own nodegroup
+The full iR Engine stack needs a builder server within the cluster in order to bundle and build
+iR Engine projects into the codebase that will be deployed. This should run on its own nodegroup
 that has a single node - only one copy of the builder should ever be running at a time, and
 due to the high memory needs of building the client service, a box with >8 GB of RAM is needed.
 
@@ -106,7 +106,7 @@ for this nodegroup. Click Next.
 On the second page, you can change the Capacity Type to `Spot` if you want to in order to save money; the builder
 service will likely not be running very often or for too long, so the odds of it getting interrupted by Spot instance
 outages are low, and it can always re-build if that does happen. Set the Disk Size to 50 GB; it takes a good deal of
-disk space to install and build the Ethereal Engine codebase, and the default 20 GB will almost certainly not be enough.
+disk space to install and build the iR Engine codebase, and the default 20 GB will almost certainly not be enough.
 
 For Instance Types, you need to only select types that have more than 8 GB; t3a.xlarge are the cheapest that fit
 this criteria. If you were to pick something with 8GB, it's highly likely that most builds would crash the node,

--- a/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/03_AWSSetup/03_ECR.md
+++ b/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/03_AWSSetup/03_ECR.md
@@ -1,10 +1,10 @@
 ## Create ECR repositories for built images.
-The Ethereal Engine deployment process will be building multiple Docker images, and those need to be stored somewhere.
+The iR Engine deployment process will be building multiple Docker images, and those need to be stored somewhere.
 In AWS, that somewhere is [Elastic Container Registry](https://us-west-1.console.aws.amazon.com/ecr/get-started).
 You need to make those repositories in the same AWS region where the EKS cluster is running.
 
 Go to the ECR link above and click Get Started under Create a Repository. If you're very concerned about any of your
-Ethereal Engine project codebase(s) getting out, you can choose Private for Visibility Settings, but normally Public is fine.
+iR Engine project codebase(s) getting out, you can choose Private for Visibility Settings, but normally Public is fine.
 You'll be needing to create multiple repositories for each deployment, e.g. several repos for a `dev` deployment,
 several more for a `prod` deployment, etc.
 
@@ -13,7 +13,7 @@ Name, e.g. `etherealengine-dev-builder`. You shouldn't need to change any other 
 repo and want to turn on Tag Immutability, that's fine. The image tags that are generated should never collide, but it
 will prevent any manual overwriting of a tag. Click Create Repository.
 
-You will need to make four more repos for each of the services that are deployed as part of the Ethereal Engine stack -
+You will need to make four more repos for each of the services that are deployed as part of the iR Engine stack -
 `api`, `client`, `instanceserver` and `taskserver`, which are also in the form `etherealengine-<RELEASE_NAME>-<service_name>`.
 e.g. `etherealengine-dev-api`, `etherealengine-dev-client`, `etherealengine-dev-instanceserver` and `etherealengine-dev-taskserver`.
 Everything else can be left alone for those, too.

--- a/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/03_AWSSetup/04_IAM.md
+++ b/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/03_AWSSetup/04_IAM.md
@@ -1,6 +1,6 @@
 ## Create IAM Roles for S3/SES/SNS (or a single admin role)
 
-Ethereal Engine interfaces with several AWS services and requires credentials for these purposes. You could make
+iR Engine interfaces with several AWS services and requires credentials for these purposes. You could make
 one admin role with full access to all AWS services, but we recommend making separate, scoped roles for
 each individual service. To create a role, do the following:
 

--- a/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/03_AWSSetup/05_RDS.md
+++ b/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/03_AWSSetup/05_RDS.md
@@ -1,6 +1,6 @@
 ## Create RDS box
 
-Ethereal Engine is backed by a SQL server. We use MariaDB in development, but it has also been run on AWS with
+iR Engine is backed by a SQL server. We use MariaDB in development, but it has also been run on AWS with
 Aurora without issue. Most other versions of SQL should work but have not been explicitly tested.
 
 ### Accessing RDS box from an external machine

--- a/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/03_AWSSetup/07_route53.md
+++ b/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/03_AWSSetup/07_route53.md
@@ -12,7 +12,7 @@ workflow to register a domain name.
 
 ### Create Route 53 Hosted Zone
 In the AWS web client, go to Route 53. Make a hosted zone for the domain you plan to use for
-your setup of Ethereal Engine. You'll be coming back here later to create DNS records.
+your setup of iR Engine. You'll be coming back here later to create DNS records.
 
 Open the Hosted zone, then click on 'Hosted zone details' to see more information. The value 'Hosted zone id'
 is used in the dev/prod.values.yaml file for 'ROUTE53_HOSTED_ZONE_ID'

--- a/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/03_AWSSetup/08_agonesNginxRedis.md
+++ b/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/03_AWSSetup/08_agonesNginxRedis.md
@@ -9,7 +9,7 @@ If that isn't present, you'll have to edit the configuration to make the appropr
 
 You next need to add the Agones, ingress-nginx, and redis Helm charts to helm by running 
 ```helm repo add agones https://agones.dev/chart/stable```, ```helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx```, and ```helm repo add redis https://charts.bitnami.com/bitnami```.
-You should also at this time add Ethereal Engine's repo via ```helm repo add etherealengine https://helm.etherealengine.org```.
+You should also at this time add iR Engine's repo via ```helm repo add etherealengine https://helm.etherealengine.org```.
 
 If you ever suspect that a chart is out-of-date, run ```helm repo update``` to update all of them to the latest.
 
@@ -20,9 +20,9 @@ This says to install a service called 'agones' from the 'agones' package in the 
 
 ### Install redis for each deployment
 
-Each deployment of Ethereal Engine uses a redis cluster for coordinating the 'feathers-sync' library.
+Each deployment of iR Engine uses a redis cluster for coordinating the 'feathers-sync' library.
 Each redis deployment needs to be named the same as the deployment that will use it; for an
-Ethereal Engine deployment named 'dev', the corresponding redis deployment would need to be named
+iR Engine deployment named 'dev', the corresponding redis deployment would need to be named
 'dev-redis'.
 
 Run ```helm install -f </path/to/redis-values.yaml> <RELEASE_NAME>-redis redis/redis``` to install, e.g.
@@ -35,10 +35,10 @@ If you named the redis nodegroup something other than 'ng-redis-1', you'll have 
 If you didn't create a nodegroup just for redis, you must omit the ` -f </path/to/redis-values.yaml> `,
 as that config makes redis pods run on a specific nodegroup.
 
-#### Installing redis as part of Ethereal Engine chart (not recommended for production)
-Redis can be installed as part of the Ethereal Engine chart so long as the config file for the Ethereal Engine installation has 'redis.enabled' set to true.
+#### Installing redis as part of iR Engine chart (not recommended for production)
+Redis can be installed as part of the iR Engine chart so long as the config file for the iR Engine installation has 'redis.enabled' set to true.
 In that case, you should skip the above step of installing redis separately. This is not recommended for production
-environments, though, since upgrades to an Ethereal Engine installation will usually reboot the redis servers,
+environments, though, since upgrades to an iR Engine installation will usually reboot the redis servers,
 leading all of the instanceservers to crash due to their redis connections being severed.
 
 This breaks Agones' normal behavior of keeping Allocated instanceservers running until every user has left and slowly replacing

--- a/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/03_AWSSetup/13_fork.md
+++ b/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/03_AWSSetup/13_fork.md
@@ -1,6 +1,6 @@
 # GitHub Fork
-## Create GitHub fork of Ethereal Engine repository.
-The Ethereal Engine codebase is most easily deployed by forking it and configuring some Secrets so that the included GitHub
+## Create GitHub fork of iR Engine repository.
+The iR Engine codebase is most easily deployed by forking it and configuring some Secrets so that the included GitHub
 Actions can run the deployment for you. You can run all of the commands that the `<dev/prod>`-deploy action runs manually
 if you so choose, and in that case, you don't need to fork the GH repo.
 

--- a/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/03_AWSSetup/16_githubActions.md
+++ b/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/03_AWSSetup/16_githubActions.md
@@ -9,14 +9,14 @@ attempt to build and deploy the builder.
 
 ### Overview of the build process
 The full build and deployment process works like this:
-1. GitHub Actions builds just enough of the Ethereal Engine monorepo to fetch any installed Ethereal Engine projects.
+1. GitHub Actions builds just enough of the iR Engine monorepo to fetch any installed iR Engine projects.
 2. GitHub Actions pushes this builder Docker image to the repo `etherealengine-<release>-builder` in ECR
 3. GitHub Actions updates the builder deployment to point to the builder image it just created.
 4. The builder deployment spins up the builder Docker image on its single node
 5. The builder connects to the deployment's database and checks if there is a table `user`. This is a proxy
-    for the database being seeded; if it does not exist, it seeds the database with the basic Ethereal Engine schema,
+    for the database being seeded; if it does not exist, it seeds the database with the basic iR Engine schema,
     seeds the default project into the database and storage provider, and seeds various types.
-6. The builder downloads any Ethereal Engine projects that the deployment has added.
+6. The builder downloads any iR Engine projects that the deployment has added.
 7. The builder builds the Docker image for each service concurrently using these projects, building them into the client files as well as copying them so that the api and instanceservers have access to them.
     If serving client files from the Storage Provider, the client files will be pushed to S3
 8. The builder pushes these final Docker images to the repos `etherealengine-<release>-<service>` in ECR (not the client image if serving client files from the Storage Provider)

--- a/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/03_AWSSetup/index.md
+++ b/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/03_AWSSetup/index.md
@@ -1,7 +1,7 @@
 import DocCardList from '@theme/DocCardList'
 
-# Ethereal Engine on AWS
-In this section you will learn how to setup Ethereal Engine with AWS.
+# iR Engine on AWS
+In this section you will learn how to setup iR Engine with AWS.
 
 :::note
 The value `RELEASE_NAME` referenced throughout this guide is the name of the deployment  

--- a/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/03_installingProjects.md
+++ b/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/03_installingProjects.md
@@ -20,12 +20,12 @@ the stack (with `npm run dev`).
 
 Projects can also be installed and managed from the /admin/projects route. You must be
 an admin and must have a linked GitHub account, which can be attained by having your
-GitHub account linked to your Ethereal Engine account by signing in via GitHub.
+GitHub account linked to your iR Engine account by signing in via GitHub.
 (You do not need to have most recently signed in via GitHub, you just have to have
 linked your GH account at some point)
 
 See [the section 'How to set up GitHub to install external projects'](./setupGithubOAuth)
-for instructions on creating an OAuth app from GitHub, installing it into an Ethereal Engine deployment,
+for instructions on creating an OAuth app from GitHub, installing it into an iR Engine deployment,
 and authorizing it to have access to your GitHub organizations.
 
 Click the 'Add Project' button:
@@ -116,7 +116,7 @@ in the storage provider, and are downloaded anew by a client each time the scene
 scenes will always be immediately available. The act of saving a project will clear any cached version
 of the scene's static files, so the client will get the new version.
 
-Additionally, if you want to update the core Ethereal Engine code, you will also need to re-run the builder
+Additionally, if you want to update the core iR Engine code, you will also need to re-run the builder
 process with the new version of the code.
 
 In a production environment, click on the button `Update Engine/Rebuild`. A drawer will open with

--- a/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/04_databaseMigrations.md
+++ b/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/04_databaseMigrations.md
@@ -1,7 +1,7 @@
 # Database Migrations
 
 ## Create Migration File
-1. Run the following command in your Ethereal Engine repo:
+1. Run the following command in your iR Engine repo:
 ```bash
 cd packages/server-core
 ```
@@ -18,6 +18,6 @@ npm run migrate:make -- {NAME}
 Our server is set up with Swagger documentation to automatically generate from most endpoints.  
 A few custom routes are not documented, but most of the basic stuff is.
 
-You can see the OpenAPI docs in on our [dev cluster](https://api-dev.etherealengine.com/openapi), or locally for a running Ethereal Engine instance at:  
+You can see the OpenAPI docs in on our [dev cluster](https://api-dev.etherealengine.com/openapi), or locally for a running iR Engine instance at:  
 https://localhost:3030/openapi
 

--- a/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/05_setupGithubOAuth.md
+++ b/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/05_setupGithubOAuth.md
@@ -1,11 +1,11 @@
 # How to set up GitHub to install external projects
 
-Ethereal Engine is extensible via [Projects](/manual/concepts/projects), which can contain
-new scenes, new avatars, new static resources, additional code, and more. Ethereal Engine integrates
+iR Engine is extensible via [Projects](/manual/concepts/projects), which can contain
+new scenes, new avatars, new static resources, additional code, and more. iR Engine integrates
 with GitHub to push and pull projects for backup and restoration, and one can also install existing
 projects from GitHub. In order to install projects from private repositories, or to push local project 
 changes to a GitHub repo, an OAuth app from GitHub (not a GitHub app, that is something different) needs to be
-created, and the logged-in user must be connected in Ethereal Engine to GitHub (i.e. must have logged in via
+created, and the logged-in user must be connected in iR Engine to GitHub (i.e. must have logged in via
 GitHub at some point) and have permission to access the source and destination repositories.
 
 Note that it is recommended that you complete most of this before the initial installation of
@@ -39,7 +39,7 @@ Here, you will generate one credential for the app, so that your deployment can 
 
 ### Make note of Client ID
 Near the top of this page is the Client ID for the app. This is a public ID for the app.
-It will be used when configuring Ethereal Engine.
+It will be used when configuring iR Engine.
 
 ### Generate client secret
 Below `Client ID` is a section `Client secrets`. None are created by default, so click the
@@ -47,7 +47,7 @@ button `Generate a new client secret`. As the notifications that appear say, you
 full secret right now, so copy it somewhere retrievable (but not anywhere publicly accessible). If 
 you ever lose the secret, you can always generate a new one.
 
-## Configure Ethereal Engine deployment with IDs/keys
+## Configure iR Engine deployment with IDs/keys
 
 ### Pre-initial installation 
 If you have not done the initial installation/deployment yet, then you can add most of the values
@@ -96,7 +96,7 @@ Once this is done, you should be able to log in with GitHub and be granted admin
 # Logging in with GitHub and Granting Access to Other Organizations
 
 When you log in with GitHub, you will be asked to grant access to your user information as well as the repositories
-that the OAuth app has authorized for. Ethereal Engine will have access to your personal repositories and,
+that the OAuth app has authorized for. iR Engine will have access to your personal repositories and,
 if the OAuth app was created in a GitHub organization, all repositories in that organization. It will not
 have inherent push access to other organizations' repositories or pull access to their private repositories.
 
@@ -115,11 +115,11 @@ will bypass this page[^1]. In order to grant the OAuth app access to other organ
 In short form:
 
 1. Go to (https://github.com/settings/applications)
-2. Click on the name of the OAuth app installed in Ethereal Engine
-3. Under `Organization access`, click on Grant/Request for the organizations you want Ethereal Engine to
+2. Click on the name of the OAuth app installed in iR Engine
+3. Under `Organization access`, click on Grant/Request for the organizations you want iR Engine to
    have access to
 
-# Installing Ethereal Engine projects from GitHub
+# Installing iR Engine projects from GitHub
 
 See [the section 'Graphical Install Flow](/manual/concepts/projects) for more information on how to install
 projects from GitHub.
@@ -128,7 +128,7 @@ projects from GitHub.
 
 Users can push projects to GitHub if they have write/maintain/admin access to the associated GitHub repository.
 Since fetching this access from the GitHub API every time a user fetches their projects can take a noticeable
-amount of time, Ethereal Engine stores users' GitHub repo access in its database. This is much faster to access.
+amount of time, iR Engine stores users' GitHub repo access in its database. This is much faster to access.
 
 There are multiple actions that will make the engine re-fetch and update users' repo access:
 
@@ -138,8 +138,8 @@ There are multiple actions that will make the engine re-fetch and update users' 
 * Via a GitHub webhook - must manually configure this
 
 ## Setting up GitHub webhook
-Ethereal Engine currently only supports webhook notifications for Collaborators being added/edited/removed. 
-Changes in Teams are not handled by Ethereal Engine due to the opacity of team members. (Team change webhooks do not 
+iR Engine currently only supports webhook notifications for Collaborators being added/edited/removed. 
+Changes in Teams are not handled by iR Engine due to the opacity of team members. (Team change webhooks do not 
 include team members, and the engine does not track who is in a team)
 
 An admin needs to go to /admin/settings, click on 'Server', then enter a secret key in the field 

--- a/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/07_releaseHelmChart.md
+++ b/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/07_releaseHelmChart.md
@@ -1,6 +1,6 @@
 # Release Helm Chart
 <!-- TODO: Improve the formatting of this file -->
-These are the steps that needs to be taken in order to update an Ethereal Engine Helm charts repo:
+These are the steps that needs to be taken in order to update an iR Engine Helm charts repo:
 > Pre-requisites:
 > - Have a checked-out copy of https://github.com/EtherealEngine/ethereal-engine-helm  
 >   set to the `gh-pages` branch

--- a/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/_acceptCertificates.md
+++ b/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/_acceptCertificates.md
@@ -1,6 +1,6 @@
 Since there are no valid certificates for this domain, you'll have to tell your browser to ignore the insecure connections when you try to load the application.
 
-Go to \<https://local.etherealengine.org/>, you should see a warning about an invalid certificate; accept this invalid cert to get to the home page. Next if it keeps displaying 'loading routes' progress for a long time, it is due to the fact that you have to allow certificates. You'll have to open the dev tools for your browser and go to the 'Console' tab. You will see some errors in URL address starting with 'wss'. Replace 'wss' with 'https' and open it in new tab. Accept the certificate and reload your Ethereal Engine tab. You need to do this for following domains:
+Go to \<https://local.etherealengine.org/>, you should see a warning about an invalid certificate; accept this invalid cert to get to the home page. Next if it keeps displaying 'loading routes' progress for a long time, it is due to the fact that you have to allow certificates. You'll have to open the dev tools for your browser and go to the 'Console' tab. You will see some errors in URL address starting with 'wss'. Replace 'wss' with 'https' and open it in new tab. Accept the certificate and reload your iR Engine tab. You need to do this for following domains:
 
 - wss://api-local.etherealengine.org -> https://api-local.etherealengine.org
 - wss://instanceserver-local.etherealengine.org -> https://instanceserver-local.etherealengine.org

--- a/docs/manual/03_modules/05_infrastructure/98_tutorials/_category_.yml
+++ b/docs/manual/03_modules/05_infrastructure/98_tutorials/_category_.yml
@@ -2,4 +2,4 @@ label: DevOps Tutorials
 position: 98
 link:
   type: generated-index
-  description: In this section you will find tutorials for hosting Ethereal Engine and its tech stack.
+  description: In this section you will find tutorials for hosting iR Engine and its tech stack.

--- a/docs/manual/96_faq.md
+++ b/docs/manual/96_faq.md
@@ -1,7 +1,7 @@
 # Frequently Asked Questions
 
 ## Is it free to use?
-Ethereal is a general purpose engine and platform that can be used by creators to provide access to fully customizable experiences.
+iR Engine is a general purpose engine and platform that can be used by creators to provide access to fully customizable experiences.
 
 The engine itself is open source, under a `CPAL` license. Anyone can host iR Engine for free in their own device.
 

--- a/docs/manual/96_faq.md
+++ b/docs/manual/96_faq.md
@@ -3,7 +3,7 @@
 ## Is it free to use?
 Ethereal is a general purpose engine and platform that can be used by creators to provide access to fully customizable experiences.
 
-The engine itself is open source, under a `CPAL` license. Anyone can host Ethereal Engine for free in their own device.
+The engine itself is open source, under a `CPAL` license. Anyone can host iR Engine for free in their own device.
 
 It is up to each creator to decide if the services they provide should be paid or free, and who has access to the experiences and services they provide.
 Examples:
@@ -14,10 +14,10 @@ Examples:
 
 ## Do I need a powerful computer?
 Performance on each individual device will depend on its hardware and how each individual experience was created. Some experiences will require more resources than others.  
-But in all cases, Ethereal Engine will automatically adapt to your device to ensure a good balance between quality and performance.
+But in all cases, iR Engine will automatically adapt to your device to ensure a good balance between quality and performance.
 
 ## What devices do I need to use?
-Ethereal Engine is built to be compatible across all devices including desktop, mobile, tablet, VR, and AR devices.
+iR Engine is built to be compatible across all devices including desktop, mobile, tablet, VR, and AR devices.
 
 
 <!-- TODO: Make a `TroubleShooting` section,                -->
@@ -26,5 +26,5 @@ Ethereal Engine is built to be compatible across all devices including desktop, 
 Try turning off ad blocker, and make sure your browser is up to date.
 
 ## What is the maximum concurrent users?
-The maximum concurrent users depends on the complexity and fidelity of your environment and avatars. Ethereal Engine can support up to several thousand users with scaled avatars, or just a dozen for a high-definition intimate experience. 
+The maximum concurrent users depends on the complexity and fidelity of your environment and avatars. iR Engine can support up to several thousand users with scaled avatars, or just a dozen for a high-definition intimate experience. 
 

--- a/docs/manual/98_contributing/06_documentation/02_markdown.md
+++ b/docs/manual/98_contributing/06_documentation/02_markdown.md
@@ -5,7 +5,7 @@ import TabItem from '@theme/TabItem';
 This page will explain how to format your content to fit the standard used by this website.  
 
 :::important
-Ethereal Engine documentation uses a **very restricted** set of GitHub Markdown for formatting its content.  
+iR Engine documentation uses a **very restricted** set of GitHub Markdown for formatting its content.  
 Multitude of otherwise perfectly legal markdown rules are strictly forbidden by this standard.  
 
 Please make sure to pay extra attention to these rules if you are already accustomed to markdown syntax.
@@ -18,7 +18,7 @@ It has a very intuitive and easy to understand syntax that can also give format 
 One of its key features is how **flexible** it is.  
 But, at the same time, this flexibility is also its biggest problem.  
 
-Maintaining a cohesive format across a team with different users/writers that all have their own unique quirks and style for writing markdown, and all contribute to a project of the size of Ethereal Engine's Documentation _(this website)_, is extremely challenging without having a single and unified standard.
+Maintaining a cohesive format across a team with different users/writers that all have their own unique quirks and style for writing markdown, and all contribute to a project of the size of iR Engine's Documentation _(this website)_, is extremely challenging without having a single and unified standard.
 
 ## The solution
 Compressing the wide range of styling and formatting options that Markdown offers, down into a very minimal and simplified ruleset, pretty much solves the problem altogether.  

--- a/docs/manual/98_contributing/index.md
+++ b/docs/manual/98_contributing/index.md
@@ -28,23 +28,23 @@ TODO List of things to contribute:   (This page should explain all of them)
 ## Create and Host your own worlds
 <Host />
 
-## Promote Ethereal Engine
+## Promote iR Engine
 <Promote />
 
-## Contribute to Ethereal Engine's development
+## Contribute to iR Engine's development
 <Develop />
 
 ## Testing and reporting issues
 <Test />
 
-## Contribute to Ethereal Engine's documentation
+## Contribute to iR Engine's documentation
 <Documentation />
 
-## Translate Ethereal Engine
+## Translate iR Engine
 <Translate />
 
 <!--
 TODO
-## Donate to Ethereal Engine
+## Donate to iR Engine
 -->
 

--- a/docs/manual/_partials/acceptCertificates.md
+++ b/docs/manual/_partials/acceptCertificates.md
@@ -3,11 +3,11 @@ When loading the engine's website for the first time you'll have to tell your br
 2. You will see some errors in URL addresses starting with `wss`
     - Replace `wss` with `https` and open that URL in a new tab
     - Accept the certificate
-    - Reload your Ethereal Engine's tab
+    - Reload your iR Engine's tab
 3. You will see some errors in URL addresses starting with `https://localhost:9000`
     - Open the URL linked in one of those errors
     - Accept the certificate
-    - Reload your Ethereal Engine's tab
+    - Reload your iR Engine's tab
 
 You need to do this for the following domains:
 - `wss://api-local.etherealengine.org` -> https://api-local.etherealengine.org
@@ -17,4 +17,4 @@ You need to do this for the following domains:
 > If the engine's website keeps displaying `loading routes` progress for a long time, it means that you have to allow the engine's certificates.  
 
 Web browsers will throw warnings when navigating to pages with unknown certificates _(aka: insecure pages)_. You should be able to tell the browser to ignore these warnings by opening your browser's `advanced options`, but during development it is easier to just ignore the browser's warnings and accept the default certificates.  
-> _Note: You will be able to create signed certificates to replace the default ones when you deploy your own Ethereal Engine stack._
+> _Note: You will be able to create signed certificates to replace the default ones when you deploy your own iR Engine stack._

--- a/docs/manual/_partials/controlCenter/step_configurations.md
+++ b/docs/manual/_partials/controlCenter/step_configurations.md
@@ -1,14 +1,14 @@
 In this step you will need to provide the following information:
 
 - **Engine Path:**  
-  This is the location of ethereal engine source code repo.  
+  This is the location of iR Engine source code repo.  
   If the path does not contain the source code, then it will be [cloned](https://github.com/EtherealEngine/etherealengine) by the Control Center App.
   :::info[windows]
   The path must be inside your WSL Ubuntu distribution.
   :::
 
 - **Ops Path:**  
-  This is the location of ethereal engine ops source code repo.  
+  This is the location of iR Engine ops source code repo.  
   If the path does not contain the source code, then it will be [cloned](https://github.com/EtherealEngine/ethereal-engine-ops) by Control Center App.
   :::info[windows]
   The path must be inside your WSL Ubuntu distribution.

--- a/docs/manual/manual.md
+++ b/docs/manual/manual.md
@@ -13,4 +13,4 @@ This site serves as a reference for understanding complex concepts and configura
 For specific tutorials and guides, refer to:
 
 - [Become a Creator](https://etherealengine.github.io/etherealengine-docs/creator): Tutorials for using the engine's **Studio** to build metaverse experiences.
-- [Typescript guides](https://etherealengine.github.io/etherealengine-docs/developer/typescript): Guides for developers using Typescript with the iR Engine.
+- [TypeScript guides](https://etherealengine.github.io/etherealengine-docs/developer/typescript): Guides for developers using TypeScript with the iR Engine.


### PR DESCRIPTION
This PR replaces every Ethereal Engine mention in the reference Manual for technical users.