### PR TITLE
Replaced EE mentions across Developer docs and fixed typos related to TypeScript and VisualScript

### DIFF
--- a/docs/developer/typescript/01_gettingStarted/01_quickstart.md
+++ b/docs/developer/typescript/01_gettingStarted/01_quickstart.md
@@ -4,8 +4,8 @@ sidebar_label: Quickstart
 import UbuntuInstall from '../../../_partials/installUbuntu.md'
 import DefaultProjects from '../../../_partials/defaultProjects.md'
 
-# Typescript Quickstart
-This QuickStart guide will teach you the basics of Ethereal Engine, and how to run the engine for the first time.  
+# TypeScript Quickstart
+This QuickStart guide will teach you the basics of iR Engine, and how to run the engine for the first time.  
 
 ## Installation
 <UbuntuInstall />
@@ -29,7 +29,7 @@ git clone -b Step0 https://github.com/EtherealEngine/ee-tutorial-hello packages/
 npm run dev
 ```
 
-You should now be able to see the `ee-tutorial-hello` project listed in Ethereal Engine's Studio by navigating to https://localhost:3000/studio.
+You should now be able to see the `ee-tutorial-hello` project listed in iR Engine's Studio by navigating to https://localhost:3000/studio.
 
 ## Confirm the installation
 Lets make sure that our `hello world` code is running:

--- a/docs/developer/typescript/01_gettingStarted/02_hello/01_ecs.md
+++ b/docs/developer/typescript/01_gettingStarted/02_hello/01_ecs.md
@@ -24,7 +24,7 @@ Don't worry if you don't fully understand what some of them explain just yet. We
 :::
 
 ## Creating an Entity
-Creating an Entity is as simple as calling the `createEntity()` function from Ethereal Engine's `ECS`.  
+Creating an Entity is as simple as calling the `createEntity()` function from iR Engine's `ECS`.  
 This function will return an identifier that can be used to group Components into a unique and distinct Object.
 ```ts
 const entity = ECS.createEntity()
@@ -32,7 +32,7 @@ const entity = ECS.createEntity()
 
 ## Adding Components
 Components represent data that has no behavior or identification.  
-The way to attach Components to Entities is by calling the `setComponent` function from Ethereal Engine's `ECS`.
+The way to attach Components to Entities is by calling the `setComponent` function from iR Engine's `ECS`.
 
 <TechnicalNote>
 The `setComponent` function will not return anything, but it will:
@@ -40,7 +40,7 @@ The `setComponent` function will not return anything, but it will:
 - Store the Component's data in the internal records of the ECS, so it can used by the engine or accessed through the API _(eg: with `getComponent` and similar functions)_.
 </TechnicalNote>
 
-Ethereal Engine requires a specific set of Components in order to create an object that can be presented on the screen:
+iR Engine requires a specific set of Components in order to create an object that can be presented on the screen:
 - **VisibleComponent**
 - **TransformComponent**
 - **PrimitiveGeometryComponent** or **MeshComponent**

--- a/docs/developer/typescript/01_gettingStarted/02_hello/02_engine.md
+++ b/docs/developer/typescript/01_gettingStarted/02_hello/02_engine.md
@@ -4,9 +4,9 @@ sidebar_label: The Engine
 import { TechnicalNote } from '@site/src/components/TechnicalNote';
 import { UnstyledDetails } from '@site/src/components/UnstyledDetails';
 
-# Working with Ethereal Engine
-You will need three very important steps for creating a project with Ethereal Engine:
-1. Installing Ethereal Engine
+# Working with iR Engine
+You will need three very important steps for creating a project with iR Engine:
+1. Installing iR Engine
 2. Installing (or creating) a project
 3. Modify and run the source code of your project
 
@@ -21,8 +21,8 @@ Whether you followed the Quickstart guide for Ubuntu, or installed the engine wi
 You don't need to understand either of them to get started. This guide will teach you what to do every time they are needed.  
 Just remember that they are used a lot to work with the engine locally.
 
-## Installing and running Ethereal Engine 
-Ethereal Engine is a web application.  
+## Installing and running iR Engine 
+iR Engine is a web application.  
 Just like any other web application, it needs to be run in a server. And that server will provide access to the engine remotely to anyone with access to its address.
 
 We will eventually learn how to work with "deployed" versions of the engine.  
@@ -32,11 +32,11 @@ That's exactly what the Quickstart installation guide automated for us.
 As the `localhost` part of the URL indicates, we are running a `local` version of the engine.  
 
 ## Installing and running projects
-Ethereal Engine can be **extended** with projects.
+iR Engine can be **extended** with projects.
 They are equivalent to the concept of "projects" in other engines, except they are modular like npm packages _(they are npm packages too)_.
 
 The engine scans for projects mounted in the `/packages/projects/projects` sub-folder.  
-This means that we can install and run new projects by executing the following commands inside our Ethereal Engine installation folder:
+This means that we can install and run new projects by executing the following commands inside our iR Engine installation folder:
 ```bash
 git clone https://github.com/EtherealEngine/ee-tutorial-hello packages/projects/projects/ee-tutorial-hello
 npm run dev
@@ -72,9 +72,9 @@ This will become very important later on in this guide.
 :::
 
 
-## Programming with Ethereal Engine
+## Programming with iR Engine
 There are two very important steps to take in order to connect the source code of our project to the engine:
-- We need to import some Ethereal Engine's modules
+- We need to import some iR Engine's modules
 - We need to export our code so the engine can run it 
 
 ### Project Configuration File
@@ -114,7 +114,7 @@ import { TransformComponent } from '@etherealengine/spatial/src/transform/compon
 import { PrimitiveGeometryComponent } from '@etherealengine/engine/src/scene/components/PrimitiveGeometryComponent'
 ```
 We will be adding these Components to our Entity, and Components are part of the ECS pattern.  
-As such, we will need to use the Ethereal Engine ECS management functions.  
+As such, we will need to use the iR Engine ECS management functions.  
 The engine provides a convenient way to import all ECS related functions at once through the `ECS` [namespace](https://www.typescriptlang.org/docs/handbook/namespaces.html).
 ```ts title="ee-tutorial-hello/src/Hello.ts"
 import { ECS } from '@etherealengine/ecs'
@@ -153,9 +153,9 @@ GeometryTypeEnum.CylinderGeometry
 > But you can just refresh the webpage when you update your source code and the engine will load your changes correctly.  
 
 :::note
-`VSCode` is the recommended editor for programming with Ethereal Engine.  
+`VSCode` is the recommended editor for programming with iR Engine.  
 It is not required, but it is highly recommended.  
-VSCode has support for some important features and plugins that make the Ethereal Engine programming workflow really smooth and featureful.  
+VSCode has support for some important features and plugins that make the iR Engine programming workflow really smooth and featureful.  
 :::
 
 <TechnicalNote title="Solution">

--- a/docs/developer/typescript/01_gettingStarted/02_hello/03_system.md
+++ b/docs/developer/typescript/01_gettingStarted/02_hello/03_system.md
@@ -15,13 +15,13 @@ ECS.setComponent(entity, VisibleComponent)
 ECS.setComponent(entity, TransformComponent, { position: new Vector3(0, 1, 0) })
 ECS.setComponent(entity, PrimitiveGeometryComponent, { geometryType: 1 })
 ```
-- And then we asked Ethereal Engine to run our code...
+- And then we asked iR Engine to run our code...
 
 ## Wait, where is the System?
 But we never defined a `System`!
 
 In the quickstart tutorial we used a simplified code example for brevity and ease of understanding.  
-But we also broke Ethereal Engine's best practices in order to achieve that simplicity.  
+But we also broke iR Engine's best practices in order to achieve that simplicity.  
 So, lets fix that.
 
 <TechnicalNote>
@@ -43,14 +43,14 @@ So far we have been defining the code that creates our Sphere at the top level o
 This means that we relied on the module being imported when the project configuration is loaded.  
 But the correct way to do this is to define our code inside a separate function, and give that function to the `execute` parameter of a System created with `defineSystem`.  
 
-Lets start by creating a new Typescript function, and moving our ECS code into that function.  
+Lets start by creating a new TypeScript function, and moving our ECS code into that function.  
 ```ts
 // Create a function
 function /* name */ () { /* code */ }
 ```
 We will also need to make sure that our code is only run once.  
 Try to figure out a way to make your function code execute only once before looking at the solution.  
-_hint: You won't need any special engine modules for this. Just regular Typescript will work._
+_hint: You won't need any special engine modules for this. Just regular TypeScript will work._
 
 <TechnicalNote title="Solution">
 
@@ -88,8 +88,8 @@ We will learn how properly manage state later on.
 <!-- State TechnicalNote End -->
 
 :::note
-We are using a regular Typescript function in this example.  
-You could also use a Typescript arrow function if you prefer.  
+We are using a regular TypeScript function in this example.  
+You could also use a TypeScript arrow function if you prefer.  
 Both styles work perfectly well.  
 :::
 

--- a/docs/developer/typescript/01_gettingStarted/02_hello/04_component.md
+++ b/docs/developer/typescript/01_gettingStarted/02_hello/04_component.md
@@ -41,7 +41,7 @@ Solving this correctly will require us to use all of these new concepts:
 - Connect our Sphere such that it is loaded only for a specific Scene
 
 This section is quite complex, and we are going to properly explore all of these concepts in the following tutorials. So, for now, the assignments are going to be very simple.  
-We will leave the explanations for the [Ethereal Engine Basics](/developer/typescript/basics) guide.  
+We will leave the explanations for the [iR Engine Basics](/developer/typescript/basics) guide.  
 
 ## Creating a Custom Component {#create}
 You can probably already guess the name of the function we are going to use next.  
@@ -83,7 +83,7 @@ We haven't connected the Component to anything just yet!
 
 ## State Management
 We haven't talked much about State, and there is a lot to explain about it.  
-We will have an entire section explaining state management in the [Ethereal Engine Basics](/developer/typescript/basics/state) guide.  
+We will have an entire section explaining state management in the [iR Engine Basics](/developer/typescript/basics/state) guide.  
 
 I will give you this one for free.  
 This is the code that replaces our `initialized` variable from the previous page:  
@@ -96,7 +96,7 @@ initialized.set(true)  // Set our initialized state to true
 <TechnicalNote title="Note">
 Note how we wrote `if (initialized.value)` instead of just `if (initialized)`.  
 And we are modifying its value with `initialized.set(true)` instead of `initialized = true`.  
-We will explain why this is the case in the [Ethereal Engine Basics: State](/developer/typescript/basics/state) section.  
+We will explain why this is the case in the [iR Engine Basics: State](/developer/typescript/basics/state) section.  
 </TechnicalNote>
 
 This code will be very useful for our next few steps.  

--- a/docs/developer/typescript/01_gettingStarted/02_hello/05_query.md
+++ b/docs/developer/typescript/01_gettingStarted/02_hello/05_query.md
@@ -2,7 +2,7 @@ import { TechnicalNote } from '@site/src/components/TechnicalNote';
 import { UnstyledDetails } from '@site/src/components/UnstyledDetails';
 
 # Queries
-Queries are a tool provided by the `Entity Component System` pattern used by Ethereal Engine.  
+Queries are a tool provided by the `Entity Component System` pattern used by iR Engine.  
 
 In simple terms, a Query is a function that will request all entities that match a certain condition.  
 More specifically, it will return **all** entities that contain **all** Components in the list that we specify.  

--- a/docs/developer/typescript/01_gettingStarted/02_hello/90_congrats.md
+++ b/docs/developer/typescript/01_gettingStarted/02_hello/90_congrats.md
@@ -5,14 +5,14 @@ title: What's Next
 import { UnstyledDetails } from '@site/src/components/UnstyledDetails';
 
 # 🎉 Congratulations! 🎉
-You have just learned the minimal basics of working with Ethereal Engine using Typescript!  
+You have just learned the minimal basics of working with iR Engine using TypeScript!  
 
 This was an introductory tutorial to teach you the core essentials of the engine as quickly as possible.  
-But Ethereal Engine has a lot of features to explore!
+But iR Engine has a lot of features to explore!
 
 ## What's Next?
 #### Beginner
-If this is your first time using Ethereal Engine, we have prepared an [Ethereal Engine Basics](/developer/typescript/basics) tutorial for you.  
+If this is your first time using iR Engine, we have prepared an [iR Engine Basics](/developer/typescript/basics) tutorial for you.  
 It will teach you how to start expanding your knowledge of the engine without getting overwhelmed by its complexity.  
 Go to the bottom of this page, and click on "Next" to continue with your learning journey!
 
@@ -24,7 +24,7 @@ Make sure to skim-read the basics section at least once, as it gives an overview
 :::
 
 #### Advanced
-The [Manual](/manual) is where Ethereal Engine is presented in all of its complexity, without any guard-rails or hand-holding.  
+The [Manual](/manual) is where iR Engine is presented in all of its complexity, without any guard-rails or hand-holding.  
 You will also find the [Reference API](https://etherealengine.github.io/etherealengine-docs/api) really useful when writing the code of your application.  
 :::note[Advanced Note]
 Make sure to read the `Mastery Toolkit` section at least once.  

--- a/docs/developer/typescript/01_gettingStarted/02_hello/index.md
+++ b/docs/developer/typescript/01_gettingStarted/02_hello/index.md
@@ -1,7 +1,7 @@
 ---
-sidebar_label: Hello Ethereal
+sidebar_label: Hello iR Engine
 ---
-# Hello World from Ethereal Engine
+# Hello World from iR Engine
 The quickstart tutorial helped us create a project and run the engine for the first time.  
 
 This is our starting point.  
@@ -38,7 +38,7 @@ Conceptually, this is what the example project does:
 
 ## Technical overview
 In technical terms, this is what the example's source code does:
-- It imports some Ethereal Engine's typescript modules in its code 
+- It imports some iR Engine's typescript modules in its code 
 - It uses the `ECS` pattern
 - It creates an `Entity`
 - It adds a few `Components` to the Entity
@@ -49,10 +49,10 @@ Our example from the quickstart tutorial is as minimal as it can possibly be.
 But there is a lot happening already, as you can see, even in such a minimal example!  
 So, the first step we will take is to spend some time understanding how everything in the example works.
 
-Next we will get our hands into the code, and learn how to program with Ethereal Engine.
+Next we will get our hands into the code, and learn how to program with iR Engine.
 
 Then, at the end of this guide, we will have a very minimal project that we can load with the Engine.  
-But, more importantly, we will have enough knowledge to be able to continue our learning through the `Ethereal Engine: Basics` guide.  
+But, more importantly, we will have enough knowledge to be able to continue our learning through the `iR Engine: Basics` guide.  
 
 Lets not delay any longer, and get started with our journey!
 

--- a/docs/developer/typescript/02_basics/01_recap/01_styling.md
+++ b/docs/developer/typescript/02_basics/01_recap/01_styling.md
@@ -51,7 +51,7 @@ We talked about Javascript [`Arrow Functions`](https://developer.mozilla.org/en-
 
 They are specially helpful when defining Systems and Components.  
 This is how a `defineSystem` call would look like using each type of function:
-```ts title="Regular Function   : Simpler, but less common in Ethereal Engine"
+```ts title="Regular Function   : Simpler, but less common in iR Engine"
 // Our function
 function sayhello() { console.log("Hello World") }
 

--- a/docs/developer/typescript/02_basics/01_recap/03_query.md
+++ b/docs/developer/typescript/02_basics/01_recap/03_query.md
@@ -8,7 +8,7 @@ import { UnstyledDetails } from '@site/src/components/UnstyledDetails';
 Queries are the simplest concept to explain out of everything we have dealt with so far.  
 But we looked into them only briefly, so lets explore their technical properties anyway.  
 
-Ethereal Engine's `defineQuery` is a function that accepts an [`array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) of `Component` types, and will return a [JavaScript Generator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators#generator_functions). This `Generator` can then be used in a [`for`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for) loop to iterate over **all** entities that contain **all** Components in the list that we provided _(ie: our array of Components)_.
+iR Engine's `defineQuery` is a function that accepts an [`array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) of `Component` types, and will return a [JavaScript Generator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators#generator_functions). This `Generator` can then be used in a [`for`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for) loop to iterate over **all** entities that contain **all** Components in the list that we provided _(ie: our array of Components)_.
 
 :::note
 The returned Query can be named anything we want, as its name is only relevant for our project.  

--- a/docs/developer/typescript/02_basics/01_recap/04_next.md
+++ b/docs/developer/typescript/02_basics/01_recap/04_next.md
@@ -1,9 +1,9 @@
 # Overview
-The `Hello World` tutorial has taught us how to work with and create the most minimal Ethereal Engine programming example possible. But, as we are about to learn, there is a lot more to explore!
+The `Hello World` tutorial has taught us how to work with and create the most minimal iR Engine programming example possible. But, as we are about to learn, there is a lot more to explore!
 
 ## Hello World
 Lets review what we have achieved with our project. So far we:
-- Imported some Ethereal Engine's typescript modules in our file
+- Imported some iR Engine's typescript modules in our file
 - Created an entity, and gave it an `uuid` and a `name`
 - Gave the entity the ability to:
   - Be visible on the screen with a `VisibleComponent`
@@ -19,7 +19,7 @@ Lets review what we have achieved with our project. So far we:
 
 That's a lot!!!
 
-## Ethereal Engine: Basics
+## iR Engine: Basics
 In this tutorial we will expand on our knowledge, and we will add these features to the source code of our project:
 - Physics Properties: Gravity, Collision, Friction, etc
 - Logic that happens every frame at specific intervals _(eg: every fixed-frame or every visual-frame)_

--- a/docs/developer/typescript/02_basics/01_recap/index.md
+++ b/docs/developer/typescript/02_basics/01_recap/index.md
@@ -5,7 +5,7 @@ In the last step of the [Hello World Tutorial](/developer/typescript/gettingStar
 But we never really explained how we did it.
 
 We also skimmed over multiple concepts that are very important for working with the Engine. So lets start on the right foot and explain them now.  
-Also, now that we are into it, we are going to style our code in a way that matches Ethereal Engine's code a bit more.  
+Also, now that we are into it, we are going to style our code in a way that matches iR Engine's code a bit more.  
 
 Lets start with Styling.  
 <DocCardList />

--- a/docs/developer/typescript/02_basics/03_state.md
+++ b/docs/developer/typescript/02_basics/03_state.md
@@ -69,10 +69,10 @@ Global State in React is any State that can be shared between Components.
 Its purpose is being able to share updatable variables between multiple components. (eg: Accessing a variable from a child component several levels down the component tree) without having to pass their data from component to component _(called "prop-drilling")_.  
 
 React provides the [`Context`](https://react.dev/learn/passing-data-deeply-with-context) API for this exact purpose.  
-But, as we will explore in a moment, `Hookstate` and Ethereal Engine's `Hyperflux` are much better ways to manage the state of our project.  
+But, as we will explore in a moment, `Hookstate` and iR Engine's `Hyperflux` are much better ways to manage the state of our project.  
 
-## Managing State in Ethereal Engine
-There are multiple ways to keep track of state in Ethereal Engine:
+## Managing State in iR Engine
+There are multiple ways to keep track of state in iR Engine:
 - Manually maintaining the value of a variable
 - A state variable with `Hyperflux`
 - A reactor mount with `useEffect`
@@ -82,7 +82,7 @@ As you saw, we are fully responsible of book-keeping the values contained in the
 There are also strict limitations on what these values can be used for.  
 <!-- TODO: Describe what the limitations of module scope variables are -->
 
-### Ethereal Engine's Hyperflux
+### iR Engine's Hyperflux
 
 #### Hookstate
 Hookstate is a tool created to simplify state management in React applications.
@@ -95,7 +95,7 @@ The variable returned from `useState` will have:
 3. `merge()` method: Allows us to combine the current data with new data in an ergonomic way
 
 #### Hyperflux
-Ethereal Engine provides a group of functions to manage state asynchronously.  
+iR Engine provides a group of functions to manage state asynchronously.  
 
 ### `useEffect`
 We want to do some sort of side-effect whenever something happens.  

--- a/docs/developer/typescript/02_basics/05_project/index.md
+++ b/docs/developer/typescript/02_basics/05_project/index.md
@@ -5,7 +5,7 @@ draft: true
 # Hero Project
 <!--
 NOTE: This page should contain:
-- Hero Project: Showcase for Ethereal Engine's development tools and workflows
+- Hero Project: Showcase for iR Engine's development tools and workflows
 - Guide: Expands on the Basics tutorial, and teaches the user how to program the Hero Project and be comfortable with EE project development
 - Segue: Lead the user into the Beyond The Basics guide
 

--- a/docs/developer/typescript/02_basics/50_debugging.md
+++ b/docs/developer/typescript/02_basics/50_debugging.md
@@ -3,6 +3,6 @@ draft: true
 ---
 
 # Debugging
-## Using Ethereal Engine's Debugger with `\``
+## Using iR Engine's Debugger with `\``
 <!-- TODO: Link the issue to the getting started guide -->
 ## Using the Web Browser's Inspector

--- a/docs/developer/typescript/02_basics/50_locations.md
+++ b/docs/developer/typescript/02_basics/50_locations.md
@@ -27,7 +27,7 @@ While the Publish button provides a really simple and easy way to create a Locat
 On the other hand, the [Admin Panel: Locations](https://localhost:3000/admin/locations) section provides utilities to manage your existing locations or edit any of their properties.
 
 #### Creating a Location
-Lets create another Location from Admin Panel. Once Ethereal Engine is running:  
+Lets create another Location from Admin Panel. Once iR Engine is running:  
 - Navigate to the Admin Panel at https://localhost:3000/admin/locations  
 - Click on `Create Location`
 - Set the Location name to `hello2`  

--- a/docs/developer/typescript/02_basics/index.md
+++ b/docs/developer/typescript/02_basics/index.md
@@ -1,10 +1,10 @@
 ---
-sidebar_label: Ethereal Engine Basics
+sidebar_label: iR Engine Basics
 ---
 
 import DocCardList from '@theme/DocCardList';
 
-# Ethereal Engine Basics
+# iR Engine Basics
 This guide is a continuation of the [Hello World Tutorial](../gettingStarted/hello).  
 In this guide you will learn how to start expanding your knowledge of the engine beyond the Quickstart introductory guide.  
 

--- a/docs/developer/typescript/04_state/50_state.md
+++ b/docs/developer/typescript/04_state/50_state.md
@@ -4,7 +4,7 @@ draft: true
 
 
 # State Management
-All of Ethereal Engine's state management uses [Hookstate](https://hookstate.js.org/) and [React](https://react.dev/).  
+All of iR Engine's state management uses [Hookstate](https://hookstate.js.org/) and [React](https://react.dev/).  
 Together, these tools give reactive, declarative, and controlled state management across any scope.
 
 ## Scoped State

--- a/docs/developer/typescript/05_ecs/02_systems/50_order/index.md
+++ b/docs/developer/typescript/05_ecs/02_systems/50_order/index.md
@@ -8,7 +8,7 @@ import { TechnicalNote } from '@site/src/components/TechnicalNote';
 
 # Systems Execution Guide
 ## Update Loop
-Ethereal Engine uses a very similar model to [Unity's update loop](https://docs.unity3d.com/Manual/ExecutionOrder.html), by the use of a [fixed timestep](https://www.gafferongames.com/post/fix_your_timestep/) update loop.
+iR Engine uses a very similar model to [Unity's update loop](https://docs.unity3d.com/Manual/ExecutionOrder.html), by the use of a [fixed timestep](https://www.gafferongames.com/post/fix_your_timestep/) update loop.
 
 The engine defines a `frame update` process that is called once per frame.  
 Inside this frame-update process there is a `fixed update` process that operates with an `accumulator` pattern.  
@@ -16,7 +16,7 @@ This accumulator ensures that time will always step at a stable number of update
 
 _Note: Because the fixed update process is independent of frame updates, each individual frame update may execute 0-to-many fixed updates during its lifetime._
 
-Ethereal Engine implements this feature through system **pipelines**, which are collections of systems that will be executed in a specific order.
+iR Engine implements this feature through system **pipelines**, which are collections of systems that will be executed in a specific order.
 
 
 ## Execution Order

--- a/docs/developer/typescript/49_networking/_50_networking.md
+++ b/docs/developer/typescript/49_networking/_50_networking.md
@@ -21,7 +21,7 @@ const spawnAction = defineAction({
 ```
 
 ## State
-Ethereal Engine uses an 'event sourced state' paradigm for networking. That means that as a developer you publish an event and that event is performed by all instances simultaneously.
+iR Engine uses an 'event sourced state' paradigm for networking. That means that as a developer you publish an event and that event is performed by all instances simultaneously.
 
 Typically actions are going to affect state. For this example we will declare that we're going to allow any number of objects, each with their own appearance. We define state in a React like way like so:
 

--- a/docs/developer/typescript/90_roadmap/index.md
+++ b/docs/developer/typescript/90_roadmap/index.md
@@ -7,7 +7,7 @@ import Introduction from '@site/docs/_partials/roadmap/intro.md'
 import ReadingOrder from '@site/docs/_partials/roadmap/order.md'
 import TypescriptConcepts from '@site/docs/_partials/concepts/typescript.md'
 
-# Typescript Learning Roadmap
+# TypeScript Learning Roadmap
 <Introduction />
 
 ## Concepts List

--- a/docs/developer/typescript/98_contributing/index.md
+++ b/docs/developer/typescript/98_contributing/index.md
@@ -17,23 +17,23 @@ import Donate from '@site/docs/_partials/contributing/donate.md'
 ## Create and Host your own worlds
 <Host />
 
-## Promote Ethereal Engine
+## Promote iR Engine
 <Promote />
 
-## Contribute to Ethereal Engine's development
+## Contribute to iR Engine's development
 <Develop />
 
 ## Testing and reporting issues
 <Test />
 
-## Contribute to Ethereal Engine's documentation
+## Contribute to iR Engine's documentation
 <Documentation />
 
-## Translate Ethereal Engine
+## Translate iR Engine
 <Translate />
 
 <!--
 TODO
-## Donate to Ethereal Engine
+## Donate to iR Engine
 -->
 

--- a/docs/developer/typescript/typescript.md
+++ b/docs/developer/typescript/typescript.md
@@ -1,18 +1,18 @@
 ---
 sidebar_position: 00
-title: Typescript Developer
+title: TypeScript Developer
 ---
-# Become a Typescript Developer
-Here you will learn everything that there is to know about programming with Typescript + Ethereal Engine.
+# Become a TypeScript Developer
+Here you will learn everything that there is to know about programming with TypeScript + iR Engine.
 <!--
 TODO:
 This page will contain an Introduction to the Developers Learning Site.
 This page should contain:
 - Small introduction to the Developer guides
-- Explanation of VisualScript-vs-Typescript: 
+- Explanation of VisualScript-vs-TypeScript: 
   No-Code: Segue into the VisualScript Learning site
-  Typescript: Segue into the Typescript Learning Site (this site)
+  TypeScript: Segue into the TypeScript Learning Site (this site)
 
-_Programming in Ethereal Engine can be done through **Typescript**._
+_Programming in iR Engine can be done through **TypeScript**._
 _But the engine also has a visual alternative to programming, called **VisualScript**._  
 -->

--- a/docs/developer/visualscript/01_gettingStarted/02_hello/index.md
+++ b/docs/developer/visualscript/01_gettingStarted/02_hello/index.md
@@ -1,6 +1,6 @@
 ---
 draft: true
-title: Hello Visualscript
+title: Hello VisualScript
 ---
 
 # Hello World

--- a/docs/developer/visualscript/01_gettingStarted/index.md
+++ b/docs/developer/visualscript/01_gettingStarted/index.md
@@ -4,12 +4,12 @@ title: Getting Started
 
 # Getting Started with VisualScript
 <!-- TODO: Add pictures to this file -->
-_This guide will teach you how to get started programming with Ethereal Engine and VisualScript._  
+_This guide will teach you how to get started programming with iR Engine and VisualScript._  
 _Visit the [VisualScript: Introduction](/developer/visualscript) page for an overview of what VisualScript is._  
 <!-- TODO: Add VisualScript intro text as a mdx partial, instead of linking to the other page -->
 
 ## Installation
-VisualScript is preinstalled with Ethereal Engine, and can be accessed as part of the Ethereal Engine Studio.
+VisualScript is preinstalled with iR Engine, and can be accessed as part of the iR Engine Studio.
 > Note: Access to the Studio requires users to have admin or creator privileges.
 
 ## Configuration

--- a/docs/developer/visualscript/02_basics/70_project/index.md
+++ b/docs/developer/visualscript/02_basics/70_project/index.md
@@ -5,7 +5,7 @@ draft: true
 # Hero Project
 <!--
 NOTE: This page should contain:
-- Hero Project: Showcase for Ethereal Engine's development tools and workflows
+- Hero Project: Showcase for iR Engine's development tools and workflows
 - Guide: Expands on the Basics tutorial, and teaches the user how to program the Hero Project and be comfortable with EE project development
 - Segue: Lead the user into the Beyond The Basics guide
 

--- a/docs/developer/visualscript/02_basics/index.md
+++ b/docs/developer/visualscript/02_basics/index.md
@@ -1,17 +1,17 @@
 ---
 draft: true
-sidebar_label: Ethereal Engine Basics
+sidebar_label: iR Engine Basics
 ---
 
 import DocCardList from '@theme/DocCardList';
 
-# Ethereal Engine Basics
+# iR Engine Basics
 This guide is a continuation of the [Hello World Tutorial](../gettingStarted/hello).  
 In this guide you will learn how to start expanding your knowledge of the engine beyond the Quickstart introductory guide.  
 <!--
 NOTE: This section should contain:
 - Guide: Teaches a new user how to program the Hero Project and be comfortable with EE project development.
-- Hero Project: Showcase for Ethereal Engine's development tools and workflows.
+- Hero Project: Showcase for iR Engine's development tools and workflows.
 -->
 
 <DocCardList />

--- a/docs/developer/visualscript/98_contributing/index.md
+++ b/docs/developer/visualscript/98_contributing/index.md
@@ -16,19 +16,19 @@ import Donate from '@site/docs/_partials/contributing/donate.md'
 ## Create and Host your own worlds
 <Host />
 
-## Promote Ethereal Engine
+## Promote iR Engine
 <Promote />
 
 ## Testing and reporting issues
 <Test />
 
-## Contribute to Ethereal Engine's documentation
+## Contribute to iR Engine's documentation
 <Documentation />
 
-## Translate Ethereal Engine
+## Translate iR Engine
 <Translate />
 
 <!--
 TODO
-## Donate to Ethereal Engine
+## Donate to iR Engine
 -->

--- a/docs/developer/visualscript/visualscript.md
+++ b/docs/developer/visualscript/visualscript.md
@@ -1,21 +1,21 @@
 ---
 sidebar_position: 00
-title: Visualscript Developer
+title: VisualScript Developer
 ---
 
-# Become a Visualscript Developer
+# Become a VisualScript Developer
 <!-- TODO: This page will contain an Introduction to the Developers Learning Site. -->
-In this section you will learn everything that there is to know about programming with Visualscript + Ethereal Engine.
+In this section you will learn everything that there is to know about programming with VisualScript + iR Engine.
 
 <!--
 TODO:
 This page will contain an Introduction to the Developers Learning Site.
 This page should contain:
 - Small introduction to the Developer guides
-- Explanation of VisualScript-vs-Typescript: 
+- Explanation of VisualScript-vs-TypeScript: 
   No-Code: Segue into the VisualScript Learning site
-  Typescript: Segue into the Typescript Learning Site (this site)
+  TypeScript: Segue into the TypeScript Learning Site (this site)
 
-_Programming in Ethereal Engine can be done through **Typescript**._
+_Programming in iR Engine can be done through **TypeScript**._
 _But the engine also has a visual alternative to programming, called **VisualScript**._  
 -->


### PR DESCRIPTION
Summary of changes:

- Ethereal Engine -> iR Engine
- Typescript -> TypeScript
- Visualscript -> VisualScript

Fixed additional typos related to these terms found on the site as well.